### PR TITLE
Add stack navigation example

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,0 +1,5 @@
+import AppNavigator from './navigation/AppNavigator';
+
+export default function App() {
+  return <AppNavigator />;
+}

--- a/index.js
+++ b/index.js
@@ -1,0 +1,4 @@
+import { registerRootComponent } from 'expo';
+import App from './App';
+
+registerRootComponent(App);

--- a/navigation/AppNavigator.tsx
+++ b/navigation/AppNavigator.tsx
@@ -1,0 +1,36 @@
+import { DarkTheme, DefaultTheme, NavigationContainer } from '@react-navigation/native';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import { useColorScheme } from '@/hooks/useColorScheme';
+import DashboardScreen from '@/screens/DashboardScreen';
+import FormScreen from '@/screens/FormScreen';
+import InboxScreen from '@/screens/InboxScreen';
+import DraftsScreen from '@/screens/DraftsScreen';
+import OutboxScreen from '@/screens/OutboxScreen';
+import SentScreen from '@/screens/SentScreen';
+
+export type RootStackParamList = {
+  Dashboard: undefined;
+  Form: undefined;
+  Inbox: undefined;
+  Drafts: undefined;
+  Outbox: undefined;
+  Sent: undefined;
+};
+
+const Stack = createNativeStackNavigator<RootStackParamList>();
+
+export default function AppNavigator() {
+  const colorScheme = useColorScheme();
+  return (
+    <NavigationContainer theme={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
+      <Stack.Navigator initialRouteName="Dashboard">
+        <Stack.Screen name="Dashboard" component={DashboardScreen} />
+        <Stack.Screen name="Form" component={FormScreen} />
+        <Stack.Screen name="Inbox" component={InboxScreen} />
+        <Stack.Screen name="Drafts" component={DraftsScreen} />
+        <Stack.Screen name="Outbox" component={OutboxScreen} />
+        <Stack.Screen name="Sent" component={SentScreen} />
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "onsitepro",
-  "main": "expo-router/entry",
+  "main": "index.js",
   "version": "1.0.0",
   "scripts": {
     "start": "expo start",

--- a/screens/DashboardScreen.tsx
+++ b/screens/DashboardScreen.tsx
@@ -1,0 +1,10 @@
+import { ThemedView } from '@/components/ThemedView';
+import { ThemedText } from '@/components/ThemedText';
+
+export default function DashboardScreen() {
+  return (
+    <ThemedView style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+      <ThemedText type="title">Dashboard</ThemedText>
+    </ThemedView>
+  );
+}

--- a/screens/DraftsScreen.tsx
+++ b/screens/DraftsScreen.tsx
@@ -1,0 +1,10 @@
+import { ThemedView } from '@/components/ThemedView';
+import { ThemedText } from '@/components/ThemedText';
+
+export default function DraftsScreen() {
+  return (
+    <ThemedView style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+      <ThemedText type="title">Drafts</ThemedText>
+    </ThemedView>
+  );
+}

--- a/screens/FormScreen.tsx
+++ b/screens/FormScreen.tsx
@@ -1,0 +1,10 @@
+import { ThemedView } from '@/components/ThemedView';
+import { ThemedText } from '@/components/ThemedText';
+
+export default function FormScreen() {
+  return (
+    <ThemedView style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+      <ThemedText type="title">Form</ThemedText>
+    </ThemedView>
+  );
+}

--- a/screens/InboxScreen.tsx
+++ b/screens/InboxScreen.tsx
@@ -1,0 +1,10 @@
+import { ThemedView } from '@/components/ThemedView';
+import { ThemedText } from '@/components/ThemedText';
+
+export default function InboxScreen() {
+  return (
+    <ThemedView style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+      <ThemedText type="title">Inbox</ThemedText>
+    </ThemedView>
+  );
+}

--- a/screens/OutboxScreen.tsx
+++ b/screens/OutboxScreen.tsx
@@ -1,0 +1,10 @@
+import { ThemedView } from '@/components/ThemedView';
+import { ThemedText } from '@/components/ThemedText';
+
+export default function OutboxScreen() {
+  return (
+    <ThemedView style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+      <ThemedText type="title">Outbox</ThemedText>
+    </ThemedView>
+  );
+}

--- a/screens/SentScreen.tsx
+++ b/screens/SentScreen.tsx
@@ -1,0 +1,10 @@
+import { ThemedView } from '@/components/ThemedView';
+import { ThemedText } from '@/components/ThemedText';
+
+export default function SentScreen() {
+  return (
+    <ThemedView style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+      <ThemedText type="title">Sent</ThemedText>
+    </ThemedView>
+  );
+}


### PR DESCRIPTION
## Summary
- create dashboard, form, inbox, drafts, outbox and sent screens
- build a stack navigator with `createNativeStackNavigator`
- expose the navigator via `App.tsx` and register it in `index.js`
- set `index.js` as the entry point

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_68720a8cae84832888ba61155af8538e