### PR TITLE
Add Dashboard screen with navigation and demo form

### DIFF
--- a/navigation/AppNavigator.tsx
+++ b/navigation/AppNavigator.tsx
@@ -8,9 +8,11 @@ import DraftsScreen from '@/screens/DraftsScreen';
 import OutboxScreen from '@/screens/OutboxScreen';
 import SentScreen from '@/screens/SentScreen';
 
+import type { FormSchema } from '@/components/FormRenderer';
+
 export type RootStackParamList = {
   Dashboard: undefined;
-  Form: undefined;
+  Form: { schema: FormSchema };
   Inbox: undefined;
   Drafts: undefined;
   Outbox: undefined;

--- a/screens/DashboardScreen.tsx
+++ b/screens/DashboardScreen.tsx
@@ -1,10 +1,49 @@
-import { ThemedView } from '@/components/ThemedView';
-import { ThemedText } from '@/components/ThemedText';
+import {
+  Button,
+  SafeAreaView,
+  ScrollView,
+  StyleSheet,
+} from 'react-native';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { useNavigation } from '@react-navigation/native';
+
+import { Colors } from '@/constants/Colors';
+import { useColorScheme } from '@/hooks/useColorScheme';
+import { RootStackParamList } from '@/navigation/AppNavigator';
+import type { FormSchema } from '@/components/FormRenderer';
 
 export default function DashboardScreen() {
+  const navigation = useNavigation<
+    NativeStackNavigationProp<RootStackParamList>
+  >();
+  const colorScheme = useColorScheme() ?? 'light';
+
+  const demoSchema: FormSchema = [
+    { type: 'text', label: 'Full Name', key: 'fullName', required: true },
+    { type: 'date', label: 'Date of Visit', key: 'visitDate' },
+    { type: 'photo', label: 'Take a Picture', key: 'photo' },
+  ];
+
   return (
-    <ThemedView style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
-      <ThemedText type="title">Dashboard</ThemedText>
-    </ThemedView>
+    <SafeAreaView style={{ flex: 1 }}>
+      <ScrollView contentContainerStyle={styles.container}>
+        <Button title="Inbox" onPress={() => navigation.navigate('Inbox')} />
+        <Button title="Drafts" onPress={() => navigation.navigate('Drafts')} />
+        <Button title="Outbox" onPress={() => navigation.navigate('Outbox')} />
+        <Button title="Sent" onPress={() => navigation.navigate('Sent')} />
+        <Button
+          title="Create New Form"
+          onPress={() => navigation.navigate('Form', { schema: demoSchema })}
+          color={Colors[colorScheme].tint}
+        />
+      </ScrollView>
+    </SafeAreaView>
   );
 }
+
+const styles = StyleSheet.create({
+  container: {
+    padding: 16,
+    gap: 16,
+  },
+});

--- a/screens/DraftsScreen.tsx
+++ b/screens/DraftsScreen.tsx
@@ -4,7 +4,7 @@ import { ThemedText } from '@/components/ThemedText';
 export default function DraftsScreen() {
   return (
     <ThemedView style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
-      <ThemedText type="title">Drafts</ThemedText>
+      <ThemedText type="title">Drafts Screen</ThemedText>
     </ThemedView>
   );
 }

--- a/screens/FormScreen.tsx
+++ b/screens/FormScreen.tsx
@@ -1,10 +1,19 @@
-import { ThemedView } from '@/components/ThemedView';
-import { ThemedText } from '@/components/ThemedText';
+import { SafeAreaView } from 'react-native';
+import { NativeStackScreenProps } from '@react-navigation/native-stack';
 
-export default function FormScreen() {
+import { ThemedView } from '@/components/ThemedView';
+import FormRenderer from '@/components/FormRenderer';
+import { RootStackParamList } from '@/navigation/AppNavigator';
+
+type Props = NativeStackScreenProps<RootStackParamList, 'Form'>;
+
+export default function FormScreen({ route }: Props) {
+  const { schema } = route.params;
   return (
-    <ThemedView style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
-      <ThemedText type="title">Form</ThemedText>
-    </ThemedView>
+    <SafeAreaView style={{ flex: 1 }}>
+      <ThemedView style={{ flex: 1 }}>
+        <FormRenderer schema={schema} />
+      </ThemedView>
+    </SafeAreaView>
   );
 }

--- a/screens/InboxScreen.tsx
+++ b/screens/InboxScreen.tsx
@@ -4,7 +4,7 @@ import { ThemedText } from '@/components/ThemedText';
 export default function InboxScreen() {
   return (
     <ThemedView style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
-      <ThemedText type="title">Inbox</ThemedText>
+      <ThemedText type="title">Inbox Screen</ThemedText>
     </ThemedView>
   );
 }

--- a/screens/OutboxScreen.tsx
+++ b/screens/OutboxScreen.tsx
@@ -4,7 +4,7 @@ import { ThemedText } from '@/components/ThemedText';
 export default function OutboxScreen() {
   return (
     <ThemedView style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
-      <ThemedText type="title">Outbox</ThemedText>
+      <ThemedText type="title">Outbox Screen</ThemedText>
     </ThemedView>
   );
 }

--- a/screens/SentScreen.tsx
+++ b/screens/SentScreen.tsx
@@ -4,7 +4,7 @@ import { ThemedText } from '@/components/ThemedText';
 export default function SentScreen() {
   return (
     <ThemedView style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
-      <ThemedText type="title">Sent</ThemedText>
+      <ThemedText type="title">Sent Screen</ThemedText>
     </ThemedView>
   );
 }


### PR DESCRIPTION
## Summary
- implement new DashboardScreen with navigation buttons
- update placeholder screens to show the screen titles
- integrate FormScreen to render a schema passed via navigation
- adjust RootStackParamList to allow passing form schemas

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module expo)*

------
https://chatgpt.com/codex/tasks/task_e_68720d5335e08328bd6e36434602793f