### PR TITLE
Implement draft save feature

### DIFF
--- a/screens/FormScreen.tsx
+++ b/screens/FormScreen.tsx
@@ -1,15 +1,37 @@
-import { SafeAreaView } from 'react-native';
+import { Button, SafeAreaView } from 'react-native';
+import { useRef } from 'react';
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { v4 as uuidv4 } from 'uuid';
 
 import { ThemedView } from '@/components/ThemedView';
 import { ThemedText } from '@/components/ThemedText';
-import FormRenderer from '@/components/FormRenderer';
+import FormRenderer, { type FormRendererRef } from '@/components/FormRenderer';
 import { RootStackParamList } from '@/navigation/AppNavigator';
+import { saveDraft, type DraftForm } from '@/services/draftService';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'Form'>;
 
 export default function FormScreen({ route }: Props) {
-  const { schema, formName } = route.params;
+  const { schema, formName, formType = 'demo' } = route.params;
+  const formRef = useRef<FormRendererRef>(null);
+
+  const handleSaveDraft = async () => {
+    const data = formRef.current?.getFormData() ?? {};
+    const timestamp = new Date().toISOString();
+    const draft: DraftForm = {
+      id: uuidv4(),
+      name: formName ?? 'Untitled Form',
+      formType,
+      schema,
+      data,
+      status: 'draft',
+      isSynced: false,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    };
+    await saveDraft(draft);
+  };
+
   return (
     <SafeAreaView style={{ flex: 1 }}>
       <ThemedView style={{ flex: 1 }}>
@@ -18,7 +40,8 @@ export default function FormScreen({ route }: Props) {
             {formName}
           </ThemedText>
         )}
-        <FormRenderer schema={schema} />
+        <FormRenderer ref={formRef} schema={schema} />
+        <Button title="Save Draft" onPress={handleSaveDraft} />
       </ThemedView>
     </SafeAreaView>
   );

--- a/services/draftService.ts
+++ b/services/draftService.ts
@@ -1,0 +1,44 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import type { FormSchema } from '@/components/FormRenderer';
+
+export type DraftForm = {
+  id: string;
+  name: string;
+  formType: string;
+  schema: FormSchema;
+  data: Record<string, any>;
+  status: 'draft';
+  isSynced: boolean;
+  createdAt: string;
+  updatedAt: string;
+};
+
+const INDEX_KEY = 'drafts:index';
+
+export async function saveDraft(draft: DraftForm) {
+  await AsyncStorage.setItem(`draft:${draft.id}`, JSON.stringify(draft));
+  const indexRaw = await AsyncStorage.getItem(INDEX_KEY);
+  const index = indexRaw ? (JSON.parse(indexRaw) as string[]) : [];
+  if (!index.includes(draft.id)) {
+    index.push(draft.id);
+    await AsyncStorage.setItem(INDEX_KEY, JSON.stringify(index));
+  }
+}
+
+export async function getAllDrafts(): Promise<DraftForm[]> {
+  const indexRaw = await AsyncStorage.getItem(INDEX_KEY);
+  const index = indexRaw ? (JSON.parse(indexRaw) as string[]) : [];
+  const drafts: DraftForm[] = [];
+  for (const id of index) {
+    const item = await AsyncStorage.getItem(`draft:${id}`);
+    if (item) {
+      drafts.push(JSON.parse(item) as DraftForm);
+    }
+  }
+  return drafts;
+}
+
+export async function getDraftById(id: string): Promise<DraftForm | null> {
+  const item = await AsyncStorage.getItem(`draft:${id}`);
+  return item ? ((JSON.parse(item) as DraftForm) ?? null) : null;
+}


### PR DESCRIPTION
## Summary
- implement saving form drafts to AsyncStorage
- expose draft utility functions: saveDraft, getAllDrafts, getDraftById
- wire up Save Draft button in FormScreen

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_687221f7b7788328ad3023465810d60b