### PR TITLE
Implement draft list view

### DIFF
--- a/navigation/AppNavigator.tsx
+++ b/navigation/AppNavigator.tsx
@@ -26,7 +26,13 @@ export type TabParamList = {
 export type RootStackParamList = {
   Tabs: undefined;
   CreateForm: undefined;
-  Form: { schema: FormSchema; formType?: string; formName?: string };
+  Form: {
+    schema: FormSchema;
+    formType?: string;
+    formName?: string;
+    data?: Record<string, any>;
+    draftId?: string;
+  };
 };
 
 const Tab = createBottomTabNavigator<TabParamList>();

--- a/screens/DraftsScreen.tsx
+++ b/screens/DraftsScreen.tsx
@@ -1,5 +1,6 @@
-import { StyleSheet, Pressable } from 'react-native';
-import { useNavigation } from '@react-navigation/native';
+import { useCallback, useState } from 'react';
+import { StyleSheet, Pressable, FlatList, Button, View } from 'react-native';
+import { useNavigation, useFocusEffect } from '@react-navigation/native';
 import { MaterialIcons } from '@expo/vector-icons';
 
 import { ThemedView } from '@/components/ThemedView';
@@ -8,19 +9,61 @@ import { Colors } from '@/constants/Colors';
 import { useColorScheme } from '@/hooks/useColorScheme';
 import { RootStackParamList } from '@/navigation/AppNavigator';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { getAllDrafts, type DraftForm } from '@/services/draftService';
 
 export default function DraftsScreen() {
   const navigation = useNavigation<
     NativeStackNavigationProp<RootStackParamList>
   >();
   const colorScheme = useColorScheme() ?? 'light';
+  const [drafts, setDrafts] = useState<DraftForm[]>([]);
+
+  const loadDrafts = useCallback(async () => {
+    const data = await getAllDrafts();
+    setDrafts(data);
+  }, []);
+
+  useFocusEffect(
+    useCallback(() => {
+      loadDrafts();
+    }, [loadDrafts]),
+  );
+
+  const handleResume = (draft: DraftForm) => {
+    navigation.navigate('Form', {
+      schema: draft.schema,
+      formType: draft.formType,
+      formName: draft.name,
+      data: draft.data,
+      draftId: draft.id,
+    });
+  };
+
+  const renderItem = ({ item }: { item: DraftForm }) => (
+    <View style={styles.draftItem}>
+      <ThemedText type="defaultSemiBold">{item.name}</ThemedText>
+      <ThemedText style={styles.dateText}>
+        {new Date(item.createdAt).toLocaleDateString()}
+      </ThemedText>
+      <Button title="Resume" onPress={() => handleResume(item)} />
+    </View>
+  );
 
   return (
     <ThemedView style={{ flex: 1 }}>
-      <ThemedView
-        style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
-        <ThemedText type="title">Drafts Screen</ThemedText>
-      </ThemedView>
+      <FlatList
+        data={drafts}
+        keyExtractor={(item) => item.id}
+        renderItem={renderItem}
+        contentContainerStyle={
+          drafts.length === 0 ? styles.emptyContainer : styles.listContainer
+        }
+        ListEmptyComponent={
+          <ThemedView style={styles.emptyContainer}>
+            <ThemedText>No drafts found.</ThemedText>
+          </ThemedView>
+        }
+      />
       <Pressable
         style={({ pressed }) => [
           styles.fab,
@@ -48,5 +91,24 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
     elevation: 2,
+  },
+  listContainer: {
+    padding: 16,
+    gap: 16,
+  },
+  emptyContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  draftItem: {
+    gap: 4,
+    padding: 12,
+    borderWidth: 1,
+    borderColor: '#ccc',
+    borderRadius: 8,
+  },
+  dateText: {
+    marginBottom: 8,
   },
 });


### PR DESCRIPTION
## Summary
- fetch saved drafts from storage
- show drafts in a flat list
- pass draft data to the Form screen

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_687223d4c6108328949cdc5a9dee1979