### PR TITLE
Enable draft editing and navigation actions

### DIFF
--- a/components/FormRenderer.tsx
+++ b/components/FormRenderer.tsx
@@ -1,4 +1,9 @@
-import React, { forwardRef, useImperativeHandle, useState } from 'react';
+import React, {
+  forwardRef,
+  useImperativeHandle,
+  useState,
+  useEffect,
+} from 'react';
 import { Button, Image, ScrollView, StyleSheet, Text, TextInput, View } from 'react-native';
 import * as ImagePicker from 'expo-image-picker';
 import DateTimePicker, { DateTimePickerEvent } from '@react-native-community/datetimepicker';
@@ -14,6 +19,7 @@ export type FormSchema = FormField[];
 
 export type FormRendererProps = {
   schema: FormSchema;
+  initialData?: Record<string, any>;
 };
 
 export type FormRendererRef = {
@@ -21,13 +27,23 @@ export type FormRendererRef = {
 };
 
 export const FormRenderer = forwardRef<FormRendererRef, FormRendererProps>(
-  ({ schema }, ref) => {
+  ({ schema, initialData }, ref) => {
     const initialState: Record<string, any> = {};
     schema.forEach((field) => {
-      initialState[field.key] = field.type === 'photo' ? undefined : '';
+      if (initialData && field.key in initialData) {
+        initialState[field.key] = initialData[field.key];
+      } else {
+        initialState[field.key] = field.type === 'photo' ? undefined : '';
+      }
     });
     const [formState, setFormState] = useState<Record<string, any>>(initialState);
     const [activeDateKey, setActiveDateKey] = useState<string | null>(null);
+
+    useEffect(() => {
+      if (initialData) {
+        setFormState((prev) => ({ ...prev, ...initialData }));
+      }
+    }, [initialData]);
 
     useImperativeHandle(ref, () => ({
       getFormData: () => formState,


### PR DESCRIPTION
## Summary
- support initializing FormRenderer with saved data
- load existing drafts on the Form screen
- update draft saving to overwrite existing draft entries
- add Back and Create New Form actions at top of the form

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_68722ebf05388328bef4bc8a21e1e2b5