### PR TITLE
Add random values polyfill and uuid deps

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+import 'react-native-get-random-values';
 import { registerRootComponent } from 'expo';
 import App from './App';
 

--- a/package.json
+++ b/package.json
@@ -40,7 +40,9 @@
     "react-native-safe-area-context": "5.4.0",
     "react-native-screens": "~4.11.1",
     "react-native-web": "~0.20.0",
-    "react-native-webview": "13.13.5"
+    "react-native-webview": "13.13.5",
+    "react-native-get-random-values": "^1.0.0",
+    "uuid": "^9.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",


### PR DESCRIPTION
## Summary
- include `react-native-get-random-values` polyfill
- add uuid-related dependencies

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_687293b66b7883288762ffb5a4b133cc