### PR TITLE
Add Outbox list

### DIFF
--- a/screens/OutboxScreen.tsx
+++ b/screens/OutboxScreen.tsx
@@ -1,10 +1,76 @@
+import { useCallback, useState } from 'react';
+import { FlatList, StyleSheet, View, Button } from 'react-native';
+import { useFocusEffect } from '@react-navigation/native';
+
 import { ThemedView } from '@/components/ThemedView';
 import { ThemedText } from '@/components/ThemedText';
+import { getAllOutbox, type OutboxForm } from '@/services/outboxService';
 
 export default function OutboxScreen() {
+  const [forms, setForms] = useState<OutboxForm[]>([]);
+
+  const loadOutbox = useCallback(async () => {
+    const data = await getAllOutbox();
+    setForms(data);
+  }, []);
+
+  useFocusEffect(
+    useCallback(() => {
+      loadOutbox();
+    }, [loadOutbox]),
+  );
+
+  const renderItem = ({ item }: { item: OutboxForm }) => (
+    <View style={styles.item}>
+      <ThemedText type="defaultSemiBold">{item.name}</ThemedText>
+      <ThemedText style={styles.dateText}>
+        {new Date(item.createdAt).toLocaleDateString()}
+      </ThemedText>
+      <ThemedText style={styles.status}>Ready to sync</ThemedText>
+      <Button title="Sync Now" onPress={() => {}} />
+    </View>
+  );
+
   return (
-    <ThemedView style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
-      <ThemedText type="title">Outbox Screen</ThemedText>
+    <ThemedView style={{ flex: 1 }}>
+      <FlatList
+        data={forms}
+        keyExtractor={(item) => item.id}
+        renderItem={renderItem}
+        contentContainerStyle={
+          forms.length === 0 ? styles.emptyContainer : styles.listContainer
+        }
+        ListEmptyComponent={
+          <ThemedView style={styles.emptyContainer}>
+            <ThemedText>No forms in outbox.</ThemedText>
+          </ThemedView>
+        }
+      />
     </ThemedView>
   );
 }
+
+const styles = StyleSheet.create({
+  listContainer: {
+    padding: 16,
+    gap: 16,
+  },
+  emptyContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  item: {
+    gap: 4,
+    padding: 12,
+    borderWidth: 1,
+    borderColor: '#ccc',
+    borderRadius: 8,
+  },
+  dateText: {
+    marginBottom: 8,
+  },
+  status: {
+    marginBottom: 8,
+  },
+});

--- a/services/outboxService.ts
+++ b/services/outboxService.ts
@@ -1,0 +1,19 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import type { DraftForm } from './draftService';
+
+export type OutboxForm = Omit<DraftForm, 'status'> & { status: 'complete' };
+
+const INDEX_KEY = 'outbox:index';
+
+export async function getAllOutbox(): Promise<OutboxForm[]> {
+  const indexRaw = await AsyncStorage.getItem(INDEX_KEY);
+  const index = indexRaw ? (JSON.parse(indexRaw) as string[]) : [];
+  const forms: OutboxForm[] = [];
+  for (const id of index) {
+    const item = await AsyncStorage.getItem(`outbox:${id}`);
+    if (item) {
+      forms.push(JSON.parse(item) as OutboxForm);
+    }
+  }
+  return forms;
+}


### PR DESCRIPTION
## Summary
- load outbox data from `outbox:index`
- display each form in a FlatList with name, date and "Sync Now" action

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_687296944d448328a4184a5240c1a633