### PR TITLE
Add Login screen

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -5,6 +5,7 @@ import { MaterialIcons } from '@expo/vector-icons';
 import { Platform } from 'react-native';
 
 import DashboardScreen from '@/screens/DashboardScreen';
+import LoginScreen from '@/screens/LoginScreen';
 import FormScreen from '@/screens/FormScreen';
 import CreateFormScreen from '@/screens/CreateFormScreen';
 import InboxScreen from '@/screens/InboxScreen';
@@ -19,7 +20,7 @@ import type { TabParamList, RootStackParamList } from '@/navigation/types';
 
 const Tab = createBottomTabNavigator<TabParamList>();
 const Stack = createNativeStackNavigator<RootStackParamList>();
-const INITIAL_ROUTE_NAME = 'Dashboard';
+const INITIAL_ROUTE_NAME = 'Login';
 
 function MainTabs() {
   const colorScheme = useColorScheme();
@@ -104,6 +105,7 @@ export default function App() {
         screenOptions={{ headerShown: false }}
         initialRouteName={INITIAL_ROUTE_NAME}
       >
+        <Stack.Screen name="Login" component={LoginScreen} />
         <Stack.Screen name="Dashboard" component={DashboardScreen} />
         <Stack.Screen
           name="Tabs"

--- a/navigation/types.ts
+++ b/navigation/types.ts
@@ -8,6 +8,7 @@ export type TabParamList = {
 };
 
 export type RootStackParamList = {
+  Login: undefined;
   Dashboard: undefined;
   Tabs: { screen?: keyof TabParamList } | undefined;
   CreateForm: undefined;

--- a/screens/LoginScreen.tsx
+++ b/screens/LoginScreen.tsx
@@ -1,0 +1,88 @@
+import { useState } from 'react';
+import {
+  Alert,
+  Button,
+  KeyboardAvoidingView,
+  Platform,
+  SafeAreaView,
+  ScrollView,
+  StyleSheet,
+  TextInput,
+  View,
+} from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
+
+import { Colors } from '@/constants/Colors';
+import { useColorScheme } from '@/hooks/useColorScheme';
+import { RootStackParamList } from '@/navigation/types';
+
+export default function LoginScreen() {
+  const navigation =
+    useNavigation<NativeStackNavigationProp<RootStackParamList>>();
+  const colorScheme = useColorScheme() ?? 'light';
+
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+
+  const handleLogin = () => {
+    if (username === 'demo' && password === 'password') {
+      navigation.navigate('Dashboard');
+    } else {
+      Alert.alert('Invalid Login', 'Username or password is incorrect.');
+    }
+  };
+
+  return (
+    <SafeAreaView style={{ flex: 1 }}>
+      <KeyboardAvoidingView
+        style={{ flex: 1 }}
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}>
+        <ScrollView contentContainerStyle={styles.container}
+          keyboardShouldPersistTaps="handled">
+          <View style={styles.fieldContainer}>
+            <TextInput
+              placeholder="Username"
+              value={username}
+              onChangeText={setUsername}
+              style={styles.textInput}
+              autoCapitalize="none"
+            />
+          </View>
+          <View style={styles.fieldContainer}>
+            <TextInput
+              placeholder="Password"
+              value={password}
+              onChangeText={setPassword}
+              secureTextEntry
+              style={styles.textInput}
+            />
+          </View>
+          <Button
+            title="Login"
+            onPress={handleLogin}
+            color={Colors[colorScheme].tint}
+          />
+        </ScrollView>
+      </KeyboardAvoidingView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    padding: 16,
+    gap: 16,
+    flexGrow: 1,
+    justifyContent: 'center',
+  },
+  fieldContainer: {
+    gap: 8,
+  },
+  textInput: {
+    borderWidth: 1,
+    borderColor: '#ccc',
+    padding: 8,
+    borderRadius: 4,
+  },
+});


### PR DESCRIPTION
## Summary
- add LoginScreen with username and password fields
- update navigation types with Login route
- include Login in root navigator and make it initial route

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_68729a5c2c348328b224d2dd9f54a112