### PR TITLE
Persist captured photos

### DIFF
--- a/components/FormRenderer.tsx
+++ b/components/FormRenderer.tsx
@@ -6,6 +6,8 @@ import React, {
 } from 'react';
 import { Button, Image, ScrollView, StyleSheet, Text, TextInput, View } from 'react-native';
 import * as ImagePicker from 'expo-image-picker';
+import * as FileSystem from 'expo-file-system';
+import { v4 as uuidv4 } from 'uuid';
 import DateTimePicker, { DateTimePickerEvent } from '@react-native-community/datetimepicker';
 
 export type FormField = {
@@ -59,7 +61,16 @@ export const FormRenderer = forwardRef<FormRendererRef, FormRendererProps>(
         mediaTypes: ImagePicker.MediaTypeOptions.Images,
       });
       if (!result.canceled) {
-        handleChange(key, result.assets[0].uri);
+        const asset = result.assets[0];
+        const formsDir = `${FileSystem.documentDirectory}forms/`;
+        try {
+          await FileSystem.makeDirectoryAsync(formsDir, { intermediates: true });
+        } catch {}
+        const extension = asset.uri.split('.').pop() || 'jpg';
+        const filename = `${uuidv4()}.${extension}`;
+        const dest = formsDir + filename;
+        await FileSystem.copyAsync({ from: asset.uri, to: dest });
+        handleChange(key, dest);
       }
     };
 

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "expo-haptics": "~14.1.4",
     "expo-image": "~2.3.2",
     "expo-image-picker": "16.1.4",
+    "expo-file-system": "~18.1.11",
     "expo-linking": "~7.1.7",
     "expo-router": "~5.1.3",
     "expo-splash-screen": "~0.30.10",

--- a/services/photoService.ts
+++ b/services/photoService.ts
@@ -1,0 +1,9 @@
+import * as FileSystem from 'expo-file-system';
+
+export async function deleteLocalPhoto(uri: string) {
+  try {
+    await FileSystem.deleteAsync(uri, { idempotent: true });
+  } catch (err) {
+    console.log('Error deleting photo:', err);
+  }
+}


### PR DESCRIPTION
## Summary
- save captured images to FileSystem so they persist across app restarts
- add helper to delete saved images after sync
- include expo-file-system dependency

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872e39f5f80832891ac404de877e351