### PR TITLE
Add validation to dynamic forms

### DIFF
--- a/screens/FormScreen.tsx
+++ b/screens/FormScreen.tsx
@@ -63,6 +63,11 @@ export default function FormScreen({ route, navigation }: Props) {
 
   const handleSubmitForm = async () => {
     try {
+      const validation = formRef.current?.validateForm();
+      if (validation && !validation.isValid) {
+        Alert.alert('Validation Error', 'Please fill all required fields.');
+        return;
+      }
       const formData = formRef.current?.getFormData() ?? {};
       const timestamp = new Date().toISOString();
       let draft: OutboxForm | null = null;


### PR DESCRIPTION
## Summary
- implement `getVisibleFields` utility
- add validation logic and errors state in `FormRenderer`
- highlight fields with red border and show messages
- expose `validateForm` via ref and use it in form submission

## Testing
- `npm run lint` *(fails: `expo` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68736fc1a8d083289852c3117cca4bee