### PR TITLE
Add Settings tab with logout

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -18,6 +18,7 @@ import InboxScreen from '@/screens/InboxScreen';
 import LoginScreen from '@/screens/LoginScreen';
 import OutboxScreen from '@/screens/OutboxScreen';
 import SentScreen from '@/screens/SentScreen';
+import SettingsScreen from '@/screens/SettingsScreen';
 
 const Tab = createBottomTabNavigator<TabParamList>();
 const Stack = createNativeStackNavigator<RootStackParamList>();
@@ -81,11 +82,11 @@ function MainTabs() {
       />
       <Tab.Screen
         name="Settings"
-        component={SentScreen}
+        component={SettingsScreen}
         options={{
-          title: 'Sent',
+          title: 'Settings',
           tabBarIcon: ({ color }) => (
-            <MaterialIcons size={28} color={color} name="send" />
+            <MaterialIcons size={28} color={color} name="settings" />
           ),
         }}
       />
@@ -134,27 +135,24 @@ export default function App() {
   }
   return (
     <NavigationContainer theme={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
-      <Stack.Navigator screenOptions={{ headerShown: false }}>
-        {isLoggedIn ? (
-          <>
-            <Stack.Screen
-              name="Tabs"
-              component={MainTabs}
-              options={({ route }) => ({
-                headerShown: true,
-                headerTitle: getTabTitle(route),
-              })}
-            />
-            <Stack.Screen name="CreateForm" component={CreateFormScreen} />
-            <Stack.Screen name="Form" component={FormScreen} />
-          </>
-        ) : (
-          <Stack.Screen name="Login">
-            {(props) => (
-              <LoginScreen {...props} onLogin={() => setIsLoggedIn(true)} />
-            )}
-          </Stack.Screen>
-        )}
+      <Stack.Navigator
+        screenOptions={{ headerShown: false }}
+        initialRouteName={isLoggedIn ? 'Tabs' : 'Login'}>
+        <Stack.Screen name="Login">
+          {(props) => (
+            <LoginScreen {...props} onLogin={() => setIsLoggedIn(true)} />
+          )}
+        </Stack.Screen>
+        <Stack.Screen
+          name="Tabs"
+          component={MainTabs}
+          options={({ route }) => ({
+            headerShown: true,
+            headerTitle: getTabTitle(route),
+          })}
+        />
+        <Stack.Screen name="CreateForm" component={CreateFormScreen} />
+        <Stack.Screen name="Form" component={FormScreen} />
       </Stack.Navigator>
     </NavigationContainer>
   );

--- a/screens/SettingsScreen.tsx
+++ b/screens/SettingsScreen.tsx
@@ -1,0 +1,36 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { useNavigation } from '@react-navigation/native';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { Alert, Button } from 'react-native';
+
+import { ThemedView } from '@/components/ThemedView';
+import { ThemedText } from '@/components/ThemedText';
+import { RootStackParamList } from '@/navigation/types';
+
+export default function SettingsScreen() {
+  const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
+
+  const handleLogout = () => {
+    Alert.alert('Logout', 'Are you sure you want to log out?', [
+      { text: 'Cancel', style: 'cancel' },
+      {
+        text: 'Logout',
+        style: 'destructive',
+        onPress: async () => {
+          await AsyncStorage.removeItem('auth:isLoggedIn');
+          await AsyncStorage.removeItem('auth:token');
+          navigation.replace('Login');
+        },
+      },
+    ]);
+  };
+
+  return (
+    <ThemedView style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+      <ThemedText type="title" style={{ marginBottom: 16 }}>
+        Settings
+      </ThemedText>
+      <Button title="Logout" onPress={handleLogout} />
+    </ThemedView>
+  );
+}


### PR DESCRIPTION
## Summary
- create `SettingsScreen` with logout confirmation and AsyncStorage cleanup
- include Settings screen in the bottom tab navigator with a gear icon
- make login screen always available in the stack so it can be replaced after logout

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_687375b5681c83289321a8eab7af4edc