### PR TITLE
Refactor navigation with nested stacks

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,7 +1,12 @@
 import { MaterialIcons } from '@expo/vector-icons';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
-import { DarkTheme, DefaultTheme, NavigationContainer, getFocusedRouteNameFromRoute } from '@react-navigation/native';
+import {
+  DarkTheme,
+  DefaultTheme,
+  NavigationContainer,
+  getFocusedRouteNameFromRoute,
+} from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { useEffect, useState } from 'react';
 import { ActivityIndicator, Platform, View } from 'react-native';
@@ -10,7 +15,11 @@ import { HapticTab } from '@/components/HapticTab';
 import TabBarBackground from '@/components/ui/TabBarBackground';
 import { Colors } from '@/constants/Colors';
 import { useColorScheme } from '@/hooks/useColorScheme';
-import type { RootStackParamList, TabParamList } from '@/navigation/types';
+import type {
+  DraftsStackParamList,
+  MainTabParamList,
+  RootStackParamList,
+} from '@/navigation/types';
 import CreateFormScreen from '@/screens/CreateFormScreen';
 import DraftsScreen from '@/screens/DraftsScreen';
 import FormScreen from '@/screens/FormScreen';
@@ -20,14 +29,33 @@ import OutboxScreen from '@/screens/OutboxScreen';
 import SentScreen from '@/screens/SentScreen';
 import SettingsScreen from '@/screens/SettingsScreen';
 
-const Tab = createBottomTabNavigator<TabParamList>();
-const Stack = createNativeStackNavigator<RootStackParamList>();
+const Tab = createBottomTabNavigator<MainTabParamList>();
+const RootStack = createNativeStackNavigator<RootStackParamList>();
+const DraftsStack = createNativeStackNavigator<DraftsStackParamList>();
 
-function MainTabs() {
+function DraftsTabNavigator() {
+  return (
+    <DraftsStack.Navigator>
+      <DraftsStack.Screen
+        name="DraftsScreen"
+        component={DraftsScreen}
+        options={{ headerShown: false }}
+      />
+      <DraftsStack.Screen
+        name="CreateFormScreen"
+        component={CreateFormScreen}
+        options={{ title: 'Create Form' }}
+      />
+      <DraftsStack.Screen name="FormScreen" component={FormScreen} options={{ title: 'Form' }} />
+    </DraftsStack.Navigator>
+  );
+}
+
+function MainTabNavigator() {
   const colorScheme = useColorScheme();
   return (
     <Tab.Navigator
-      initialRouteName="Drafts"
+      initialRouteName="DraftsTab"
       screenOptions={{
         tabBarActiveTintColor: Colors[colorScheme ?? 'light'].tint,
         headerShown: false,
@@ -41,7 +69,7 @@ function MainTabs() {
         }),
       }}>
       <Tab.Screen
-        name="Inbox"
+        name="InboxTab"
         component={InboxScreen}
         options={{
           title: 'Inbox',
@@ -51,8 +79,8 @@ function MainTabs() {
         }}
       />
       <Tab.Screen
-        name="Drafts"
-        component={DraftsScreen}
+        name="DraftsTab"
+        component={DraftsTabNavigator}
         options={{
           title: 'Drafts',
           tabBarIcon: ({ color }) => (
@@ -61,7 +89,7 @@ function MainTabs() {
         }}
       />
       <Tab.Screen
-        name="Outbox"
+        name="OutboxTab"
         component={OutboxScreen}
         options={{
           title: 'Outbox',
@@ -71,7 +99,7 @@ function MainTabs() {
         }}
       />
       <Tab.Screen
-        name="Sent"
+        name="SentTab"
         component={SentScreen}
         options={{
           title: 'Sent',
@@ -81,7 +109,7 @@ function MainTabs() {
         }}
       />
       <Tab.Screen
-        name="Settings"
+        name="SettingsTab"
         component={SettingsScreen}
         options={{
           title: 'Settings',
@@ -95,15 +123,15 @@ function MainTabs() {
 }
 
 function getTabTitle(route: any) {
-  const routeName = getFocusedRouteNameFromRoute(route) ?? 'Drafts';
+  const routeName = getFocusedRouteNameFromRoute(route) ?? 'DraftsTab';
   switch (routeName) {
-    case 'Inbox':
+    case 'InboxTab':
       return 'Inbox';
-    case 'Outbox':
+    case 'OutboxTab':
       return 'Outbox';
-    case 'Sent':
+    case 'SentTab':
       return 'Sent';
-    case 'Settings':
+    case 'SettingsTab':
       return 'Settings';
     default:
       return 'Drafts';
@@ -135,25 +163,23 @@ export default function App() {
   }
   return (
     <NavigationContainer theme={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
-      <Stack.Navigator
+      <RootStack.Navigator
         screenOptions={{ headerShown: false }}
-        initialRouteName={isLoggedIn ? 'Tabs' : 'Login'}>
-        <Stack.Screen name="Login">
+        initialRouteName={isLoggedIn ? 'MainTabs' : 'Login'}>
+        <RootStack.Screen name="Login">
           {(props) => (
             <LoginScreen {...props} onLogin={() => setIsLoggedIn(true)} />
           )}
-        </Stack.Screen>
-        <Stack.Screen
-          name="Tabs"
-          component={MainTabs}
+        </RootStack.Screen>
+        <RootStack.Screen
+          name="MainTabs"
+          component={MainTabNavigator}
           options={({ route }) => ({
             headerShown: true,
             headerTitle: getTabTitle(route),
           })}
         />
-        <Stack.Screen name="CreateForm" component={CreateFormScreen} />
-        <Stack.Screen name="Form" component={FormScreen} />
-      </Stack.Navigator>
+      </RootStack.Navigator>
     </NavigationContainer>
   );
 }

--- a/navigation/types.ts
+++ b/navigation/types.ts
@@ -1,23 +1,27 @@
+import type { NavigatorScreenParams } from '@react-navigation/native';
 import type { FormSchema } from '@/components/FormRenderer';
 
-export type TabParamList = {
-  Drafts: undefined;
-  Inbox: undefined;
-  Outbox: undefined;
-  Sent: undefined;
-  Settings: undefined;
-};
-
-export type RootStackParamList = {
-  Login: undefined;
-  Dashboard: undefined;
-  Tabs: { screen?: keyof TabParamList } | undefined;
-  CreateForm: undefined;
-  Form: {
+export type DraftsStackParamList = {
+  DraftsScreen: undefined;
+  CreateFormScreen: undefined;
+  FormScreen: {
     schema: FormSchema;
     formType?: string;
     formName?: string;
     data?: Record<string, any>;
     draftId?: string;
   };
+};
+
+export type MainTabParamList = {
+  DraftsTab: NavigatorScreenParams<DraftsStackParamList>;
+  InboxTab: undefined;
+  OutboxTab: undefined;
+  SentTab: undefined;
+  SettingsTab: undefined;
+};
+
+export type RootStackParamList = {
+  Login: undefined;
+  MainTabs: NavigatorScreenParams<MainTabParamList> | undefined;
 };

--- a/screens/CreateFormScreen.tsx
+++ b/screens/CreateFormScreen.tsx
@@ -15,11 +15,11 @@ import type { FormSchema } from '@/components/FormRenderer';
 import { ThemedText } from '@/components/ThemedText';
 import { Colors } from '@/constants/Colors';
 import { useColorScheme } from '@/hooks/useColorScheme';
-import { RootStackParamList } from '@/navigation/types';
+import { DraftsStackParamList } from '@/navigation/types';
 
 export default function CreateFormScreen() {
   const navigation =
-    useNavigation<NativeStackNavigationProp<RootStackParamList>>();
+    useNavigation<NativeStackNavigationProp<DraftsStackParamList>>();
   const colorScheme = useColorScheme() ?? 'light';
   const [formName, setFormName] = useState('');
   const [formType, setFormType] = useState<'demo'>('demo');
@@ -68,7 +68,7 @@ export default function CreateFormScreen() {
   
 
   const handleStart = () => {
-    navigation.navigate('Form', { schema, formType, formName });
+    navigation.navigate('FormScreen', { schema, formType, formName });
   };
 
   return (

--- a/screens/DraftsScreen.tsx
+++ b/screens/DraftsScreen.tsx
@@ -16,7 +16,7 @@ import { ThemedText } from '@/components/ThemedText';
 import { ThemedView } from '@/components/ThemedView';
 import { Colors } from '@/constants/Colors';
 import { useColorScheme } from '@/hooks/useColorScheme';
-import { RootStackParamList } from '@/navigation/types';
+import { DraftsStackParamList } from '@/navigation/types';
 import {
   getAllDrafts,
   getDraftById,
@@ -27,7 +27,7 @@ import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 
 export default function DraftsScreen() {
   const navigation = useNavigation<
-    NativeStackNavigationProp<RootStackParamList>
+    NativeStackNavigationProp<DraftsStackParamList>
   >();
   const colorScheme = useColorScheme() ?? 'light';
   const [drafts, setDrafts] = useState<DraftForm[]>([]);
@@ -44,7 +44,7 @@ export default function DraftsScreen() {
   );
 
   const handleResume = (draft: DraftForm) => {
-    navigation.navigate('Form', {
+    navigation.navigate('FormScreen', {
       schema: draft.schema,
       formType: draft.formType,
       formName: draft.name,
@@ -140,7 +140,7 @@ export default function DraftsScreen() {
             opacity: pressed ? 0.8 : 1,
           },
         ]}
-        onPress={() => navigation.navigate('CreateForm')}
+        onPress={() => navigation.navigate('CreateFormScreen')}
         accessibilityLabel="Create New Form">
         <MaterialIcons name="add" size={28} color="#fff" />
       </Pressable>

--- a/screens/FormScreen.tsx
+++ b/screens/FormScreen.tsx
@@ -7,7 +7,7 @@ import { v4 as uuidv4 } from 'uuid';
 import FormRenderer, { type FormRendererRef } from '@/components/FormRenderer';
 import { ThemedText } from '@/components/ThemedText';
 import { ThemedView } from '@/components/ThemedView';
-import { RootStackParamList } from '@/navigation/types';
+import { DraftsStackParamList } from '@/navigation/types';
 import {
   getDraftById,
   saveDraft,
@@ -16,7 +16,7 @@ import {
 
 type OutboxForm = Omit<DraftForm, 'status'> & { status: 'complete' };
 
-type Props = NativeStackScreenProps<RootStackParamList, 'Form'>;
+type Props = NativeStackScreenProps<DraftsStackParamList, 'FormScreen'>;
 
 export default function FormScreen({ route, navigation }: Props) {
   const { schema, formName, formType = 'demo', draftId, data } = route.params;
@@ -139,7 +139,7 @@ export default function FormScreen({ route, navigation }: Props) {
       }
 
       console.log('Form moved to outbox:', id);
-      navigation.navigate('Tabs', { screen: 'Drafts' });
+      navigation.popToTop();
     } catch (err) {
       console.log('Error submitting form:', err);
       Alert.alert('Error', 'Failed to submit form.');
@@ -149,7 +149,7 @@ export default function FormScreen({ route, navigation }: Props) {
   return (
     <SafeAreaView style={{ flex: 1 }}>
       <ThemedView style={{ flex: 1 }}>
-        <Button title="Back" onPress={() => navigation.navigate('Tabs', { screen: 'Drafts' })} />
+        <Button title="Back" onPress={() => navigation.popToTop()} />
         {formName && (
           <ThemedText type="title" style={{ padding: 16 }}>
             {formName}

--- a/screens/LoginScreen.tsx
+++ b/screens/LoginScreen.tsx
@@ -58,7 +58,7 @@ export default function LoginScreen({ onLogin }: Props) {
         await AsyncStorage.setItem('auth:token', data.token);
         await AsyncStorage.setItem('auth:isLoggedIn', 'true');
         onLogin();
-        navigation.replace('Tabs');
+        navigation.replace('MainTabs');
       } else {
         Alert.alert('Invalid Login', 'Username or password is incorrect.');
       }


### PR DESCRIPTION
## Summary
- restructure navigation to keep tabs mounted
- create nested Drafts stack for CreateForm and Form screens
- update all navigation calls to new screens
- adjust typing for new navigators

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873a4bde46c8328ad09e51eb53a1c0f