### PR TITLE
Add outbox sync feature

### DIFF
--- a/screens/OutboxScreen.tsx
+++ b/screens/OutboxScreen.tsx
@@ -4,7 +4,11 @@ import { useFocusEffect } from '@react-navigation/native';
 
 import { ThemedView } from '@/components/ThemedView';
 import { ThemedText } from '@/components/ThemedText';
-import { getAllOutbox, type OutboxForm } from '@/services/outboxService';
+import {
+  getAllOutbox,
+  syncOutbox,
+  type OutboxForm,
+} from '@/services/outboxService';
 
 export default function OutboxScreen() {
   const [forms, setForms] = useState<OutboxForm[]>([]);
@@ -13,6 +17,11 @@ export default function OutboxScreen() {
     const data = await getAllOutbox();
     setForms(data);
   }, []);
+
+  const handleSync = async () => {
+    await syncOutbox();
+    await loadOutbox();
+  };
 
   useFocusEffect(
     useCallback(() => {
@@ -27,7 +36,7 @@ export default function OutboxScreen() {
         {new Date(item.createdAt).toLocaleDateString()}
       </ThemedText>
       <ThemedText style={styles.status}>Ready to sync</ThemedText>
-      <Button title="Sync Now" onPress={() => {}} />
+      <Button title="Sync Now" onPress={handleSync} />
     </View>
   );
 

--- a/services/outboxService.ts
+++ b/services/outboxService.ts
@@ -4,6 +4,8 @@ import type { DraftForm } from './draftService';
 export type OutboxForm = Omit<DraftForm, 'status'> & { status: 'complete' };
 
 const INDEX_KEY = 'outbox:index';
+const SENT_INDEX_KEY = 'sent:index';
+const SYNC_ENDPOINT = 'https://your-api.com/forms/submit';
 
 export async function getAllOutbox(): Promise<OutboxForm[]> {
   const indexRaw = await AsyncStorage.getItem(INDEX_KEY);
@@ -16,4 +18,43 @@ export async function getAllOutbox(): Promise<OutboxForm[]> {
     }
   }
   return forms;
+}
+
+export async function syncOutbox() {
+  const indexRaw = await AsyncStorage.getItem(INDEX_KEY);
+  let ids = indexRaw ? (JSON.parse(indexRaw) as string[]) : [];
+
+  for (const id of [...ids]) {
+    try {
+      const item = await AsyncStorage.getItem(`outbox:${id}`);
+      if (!item) continue;
+      const form = JSON.parse(item) as OutboxForm;
+
+      const response = await fetch(SYNC_ENDPOINT, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(form),
+      });
+
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+
+      const sentForm = { ...form, isSynced: true };
+      await AsyncStorage.setItem(`sent:${id}`, JSON.stringify(sentForm));
+
+      const sentIndexRaw = await AsyncStorage.getItem(SENT_INDEX_KEY);
+      const sentIndex = sentIndexRaw ? (JSON.parse(sentIndexRaw) as string[]) : [];
+      if (!sentIndex.includes(id)) {
+        sentIndex.push(id);
+        await AsyncStorage.setItem(SENT_INDEX_KEY, JSON.stringify(sentIndex));
+      }
+
+      await AsyncStorage.removeItem(`outbox:${id}`);
+      ids = ids.filter((i) => i !== id);
+      await AsyncStorage.setItem(INDEX_KEY, JSON.stringify(ids));
+    } catch (err) {
+      console.log('Error syncing form', id, err);
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- implement `syncOutbox` helper to POST unsent forms and move them to `sent` storage
- wire sync handler to the Outbox screen

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873c9d684d08328a51d1ae3235055d6