### PR TITLE
Add badge counts to tab icons

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -9,7 +9,7 @@ import {
 } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { useEffect, useState } from 'react';
-import { ActivityIndicator, Platform, View } from 'react-native';
+import { ActivityIndicator, Platform, View, Text } from 'react-native';
 
 import { HapticTab } from '@/components/HapticTab';
 import TabBarBackground from '@/components/ui/TabBarBackground';
@@ -29,6 +29,7 @@ import OutboxScreen from '@/screens/OutboxScreen';
 import SentScreen from '@/screens/SentScreen';
 import { cleanupOldSentForms } from '@/services/sentService';
 import SettingsScreen from '@/screens/SettingsScreen';
+import { FormCountsProvider, useFormCounts } from '@/context/FormCountsContext';
 
 const Tab = createBottomTabNavigator<MainTabParamList>();
 const RootStack = createNativeStackNavigator<RootStackParamList>();
@@ -54,6 +55,26 @@ function DraftsTabNavigator() {
 
 function MainTabNavigator() {
   const colorScheme = useColorScheme();
+  const { counts } = useFormCounts();
+  const renderIcon = (name: keyof typeof MaterialIcons.glyphMap, color: string, count: number) => (
+    <View>
+      <MaterialIcons size={28} color={color} name={name} />
+      {count > 0 && (
+        <View
+          style={{
+            position: 'absolute',
+            right: -6,
+            top: -4,
+            backgroundColor: 'red',
+            borderRadius: 10,
+            paddingHorizontal: 6,
+            paddingVertical: 2,
+          }}>
+          <Text style={{ color: 'white', fontSize: 10 }}>{count}</Text>
+        </View>
+      )}
+    </View>
+  );
   return (
     <Tab.Navigator
       initialRouteName="DraftsTab"
@@ -74,9 +95,7 @@ function MainTabNavigator() {
         component={InboxScreen}
         options={{
           title: 'Inbox',
-          tabBarIcon: ({ color }) => (
-            <MaterialIcons size={28} color={color} name="inbox" />
-          ),
+          tabBarIcon: ({ color }) => renderIcon('inbox', color, counts.inbox),
         }}
       />
       <Tab.Screen
@@ -84,9 +103,7 @@ function MainTabNavigator() {
         component={DraftsTabNavigator}
         options={{
           title: 'Drafts',
-          tabBarIcon: ({ color }) => (
-            <MaterialIcons size={28} color={color} name="drafts" />
-          ),
+          tabBarIcon: ({ color }) => renderIcon('drafts', color, counts.drafts),
         }}
       />
       <Tab.Screen
@@ -94,9 +111,7 @@ function MainTabNavigator() {
         component={OutboxScreen}
         options={{
           title: 'Outbox',
-          tabBarIcon: ({ color }) => (
-            <MaterialIcons size={28} color={color} name="outbox" />
-          ),
+          tabBarIcon: ({ color }) => renderIcon('outbox', color, counts.outbox),
         }}
       />
       <Tab.Screen
@@ -104,9 +119,7 @@ function MainTabNavigator() {
         component={SentScreen}
         options={{
           title: 'Sent',
-          tabBarIcon: ({ color }) => (
-            <MaterialIcons size={28} color={color} name="send" />
-          ),
+          tabBarIcon: ({ color }) => renderIcon('send', color, counts.sent),
         }}
       />
       <Tab.Screen
@@ -173,10 +186,11 @@ export default function App() {
     );
   }
   return (
-    <NavigationContainer theme={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
-      <RootStack.Navigator
-        screenOptions={{ headerShown: false }}
-        initialRouteName={isLoggedIn ? 'MainTabs' : 'Login'}>
+    <FormCountsProvider>
+      <NavigationContainer theme={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
+        <RootStack.Navigator
+          screenOptions={{ headerShown: false }}
+          initialRouteName={isLoggedIn ? 'MainTabs' : 'Login'}>
         <RootStack.Screen name="Login">
           {(props) => (
             <LoginScreen {...props} onLogin={() => setIsLoggedIn(true)} />
@@ -192,5 +206,6 @@ export default function App() {
         />
       </RootStack.Navigator>
     </NavigationContainer>
+    </FormCountsProvider>
   );
 }

--- a/context/FormCountsContext.tsx
+++ b/context/FormCountsContext.tsx
@@ -1,0 +1,32 @@
+import React, { createContext, useContext, useState } from 'react';
+
+export type FormCounts = {
+  inbox: number;
+  drafts: number;
+  outbox: number;
+  sent: number;
+};
+
+export type FormCountsContextValue = {
+  counts: FormCounts;
+  setCounts: React.Dispatch<React.SetStateAction<FormCounts>>;
+};
+
+const FormCountsContext = createContext<FormCountsContextValue | undefined>(undefined);
+
+export function FormCountsProvider({ children }: { children: React.ReactNode }) {
+  const [counts, setCounts] = useState<FormCounts>({ inbox: 0, drafts: 0, outbox: 0, sent: 0 });
+  return (
+    <FormCountsContext.Provider value={{ counts, setCounts }}>
+      {children}
+    </FormCountsContext.Provider>
+  );
+}
+
+export function useFormCounts() {
+  const ctx = useContext(FormCountsContext);
+  if (!ctx) {
+    throw new Error('useFormCounts must be used within FormCountsProvider');
+  }
+  return ctx;
+}

--- a/screens/DraftsScreen.tsx
+++ b/screens/DraftsScreen.tsx
@@ -24,6 +24,7 @@ import {
 } from '@/services/draftService';
 import { deleteLocalPhoto } from '@/services/photoService';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { useFormCounts } from '@/context/FormCountsContext';
 
 export default function DraftsScreen() {
   const navigation = useNavigation<
@@ -31,11 +32,13 @@ export default function DraftsScreen() {
   >();
   const colorScheme = useColorScheme() ?? 'light';
   const [drafts, setDrafts] = useState<DraftForm[]>([]);
+  const { setCounts } = useFormCounts();
 
   const loadDrafts = useCallback(async () => {
     const data = await getAllDrafts();
     setDrafts(data);
-  }, []);
+    setCounts((c) => ({ ...c, drafts: data.length }));
+  }, [setCounts]);
 
   useFocusEffect(
     useCallback(() => {

--- a/screens/InboxScreen.tsx
+++ b/screens/InboxScreen.tsx
@@ -1,7 +1,15 @@
+import { useEffect } from 'react';
 import { ThemedView } from '@/components/ThemedView';
 import { ThemedText } from '@/components/ThemedText';
+import { useFormCounts } from '@/context/FormCountsContext';
 
 export default function InboxScreen() {
+  const { setCounts } = useFormCounts();
+
+  useEffect(() => {
+    setCounts((c) => ({ ...c, inbox: 0 }));
+  }, [setCounts]);
+
   return (
     <ThemedView style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
       <ThemedText type="title">Inbox Screen</ThemedText>

--- a/screens/OutboxScreen.tsx
+++ b/screens/OutboxScreen.tsx
@@ -9,14 +9,17 @@ import {
   syncOutbox,
   type OutboxForm,
 } from '@/services/outboxService';
+import { useFormCounts } from '@/context/FormCountsContext';
 
 export default function OutboxScreen() {
   const [forms, setForms] = useState<OutboxForm[]>([]);
+  const { setCounts } = useFormCounts();
 
   const loadOutbox = useCallback(async () => {
     const data = await getAllOutbox();
     setForms(data);
-  }, []);
+    setCounts((c) => ({ ...c, outbox: data.length }));
+  }, [setCounts]);
 
   const handleSync = async () => {
     await syncOutbox();

--- a/screens/SentScreen.tsx
+++ b/screens/SentScreen.tsx
@@ -6,6 +6,7 @@ import { FlatList, StyleSheet, TouchableOpacity } from 'react-native';
 import { ThemedText } from '@/components/ThemedText';
 import { ThemedView } from '@/components/ThemedView';
 import type { FormSchema } from '@/components/FormRenderer';
+import { useFormCounts } from '@/context/FormCountsContext';
 
 export type SentForm = {
   id: string;
@@ -19,6 +20,7 @@ export type SentForm = {
 export default function SentScreen() {
   const navigation = useNavigation();
   const [forms, setForms] = useState<SentForm[]>([]);
+  const { setCounts } = useFormCounts();
 
   const loadSentForms = useCallback(async () => {
     try {
@@ -32,10 +34,11 @@ export default function SentScreen() {
         }
       }
       setForms(result);
+      setCounts((c) => ({ ...c, sent: result.length }));
     } catch (err) {
       console.log('Error loading sent forms:', err);
     }
-  }, []);
+  }, [setCounts]);
 
   useFocusEffect(
     useCallback(() => {


### PR DESCRIPTION
## Summary
- create `FormCountsContext` to share badge counts across screens
- wrap navigation in `FormCountsProvider`
- display badge counts on tab icons in `MainTabNavigator`
- update Inbox, Drafts, Outbox, and Sent screens to update counts

## Testing
- `npx tsc --noEmit` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_6873e1f84c2083288f980e104ab3fe18