### PR TITLE
Add status badges to form lists

### DIFF
--- a/components/StatusBadge.tsx
+++ b/components/StatusBadge.tsx
@@ -1,0 +1,32 @@
+import { StyleSheet, View } from 'react-native';
+import { ThemedText } from './ThemedText';
+
+export type StatusBadgeProps = {
+  label: string;
+  color: string;
+  icon?: string;
+};
+
+export function StatusBadge({ label, color, icon }: StatusBadgeProps) {
+  return (
+    <View style={[styles.badge, { backgroundColor: color }]}>
+      <ThemedText style={styles.text}>
+        {icon ? `${icon} ` : ''}
+        {label}
+      </ThemedText>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  badge: {
+    alignSelf: 'flex-start',
+    paddingHorizontal: 8,
+    paddingVertical: 2,
+    borderRadius: 4,
+  },
+  text: {
+    color: '#fff',
+    fontSize: 12,
+  },
+});

--- a/screens/DraftsScreen.tsx
+++ b/screens/DraftsScreen.tsx
@@ -16,6 +16,7 @@ import * as FileSystem from 'expo-file-system';
 
 import { ThemedText } from '@/components/ThemedText';
 import { ThemedView } from '@/components/ThemedView';
+import { StatusBadge } from '@/components/StatusBadge';
 import { Colors } from '@/constants/Colors';
 import { useColorScheme } from '@/hooks/useColorScheme';
 import { DraftsStackParamList } from '@/navigation/types';
@@ -146,6 +147,7 @@ export default function DraftsScreen() {
       <ThemedText style={styles.dateText}>
         {new Date(item.createdAt).toLocaleDateString()}
       </ThemedText>
+      <StatusBadge label="Draft" icon="📝" color="#6c757d" />
       <Button title="Resume" onPress={() => handleResume(item)} />
     </View>
   );

--- a/screens/FormScreen.tsx
+++ b/screens/FormScreen.tsx
@@ -28,7 +28,11 @@ import {
   type DraftForm,
 } from '@/services/draftService';
 
-type OutboxForm = Omit<DraftForm, 'status'> & { status: 'complete' };
+type OutboxForm = Omit<DraftForm, 'status'> & {
+  status: 'complete';
+  syncError?: string;
+  syncedAt?: string;
+};
 
 type Props = NativeStackScreenProps<DraftsStackParamList, 'FormScreen'>;
 
@@ -121,6 +125,8 @@ export default function FormScreen({ route, navigation }: Props) {
           data: formData,
           status: 'complete',
           isSynced: false,
+          syncError: undefined,
+          syncedAt: undefined,
           createdAt: timestamp,
           updatedAt: timestamp,
         };
@@ -129,6 +135,8 @@ export default function FormScreen({ route, navigation }: Props) {
           ...draft,
           data: formData,
           status: 'complete',
+          syncError: undefined,
+          syncedAt: undefined,
           updatedAt: timestamp,
         };
       }
@@ -296,7 +304,6 @@ export default function FormScreen({ route, navigation }: Props) {
               </View>
             </>
           )}
-        </View>
         </View>
       </ThemedView>
     </SafeAreaView>

--- a/screens/OutboxScreen.tsx
+++ b/screens/OutboxScreen.tsx
@@ -4,6 +4,7 @@ import { useFocusEffect } from '@react-navigation/native';
 
 import { ThemedView } from '@/components/ThemedView';
 import { ThemedText } from '@/components/ThemedText';
+import { StatusBadge } from '@/components/StatusBadge';
 import {
   getAllOutbox,
   syncOutbox,
@@ -48,7 +49,16 @@ export default function OutboxScreen() {
       <ThemedText style={styles.dateText}>
         {new Date(item.createdAt).toLocaleDateString()}
       </ThemedText>
-      <ThemedText style={styles.status}>Ready to sync</ThemedText>
+      {item.syncedAt && (
+        <ThemedText style={styles.dateText}>
+          Last synced at {new Date(item.syncedAt).toLocaleDateString()}
+        </ThemedText>
+      )}
+      <StatusBadge
+        label={item.syncError ? 'Failed' : 'Pending'}
+        icon={item.syncError ? '❌' : '🔄'}
+        color={item.syncError ? '#d9534f' : '#f0ad4e'}
+      />
       <Button title="Sync Now" onPress={handleSync} />
     </View>
   );
@@ -95,9 +105,6 @@ const styles = StyleSheet.create({
     borderRadius: 8,
   },
   dateText: {
-    marginBottom: 8,
-  },
-  status: {
     marginBottom: 8,
   },
 });

--- a/screens/SentScreen.tsx
+++ b/screens/SentScreen.tsx
@@ -5,6 +5,7 @@ import { FlatList, StyleSheet, TouchableOpacity } from 'react-native';
 
 import { ThemedText } from '@/components/ThemedText';
 import { ThemedView } from '@/components/ThemedView';
+import { StatusBadge } from '@/components/StatusBadge';
 import type { FormSchema } from '@/components/FormRenderer';
 import { useFormCounts } from '@/context/FormCountsContext';
 
@@ -15,6 +16,8 @@ export type SentForm = {
   schema: FormSchema;
   data: Record<string, any>;
   updatedAt: string;
+  isSynced?: boolean;
+  syncedAt?: string;
 };
 
 export default function SentScreen() {
@@ -64,8 +67,18 @@ export default function SentScreen() {
       <ThemedText type="defaultSemiBold">{item.name}</ThemedText>
       <ThemedText>{item.formType}</ThemedText>
       <ThemedText style={styles.dateText}>
-        {new Date(item.updatedAt).toLocaleDateString()}
+        Submitted {new Date(item.updatedAt).toLocaleDateString()}
       </ThemedText>
+      {item.syncedAt && (
+        <ThemedText style={styles.dateText}>
+          Last synced at {new Date(item.syncedAt).toLocaleDateString()}
+        </ThemedText>
+      )}
+      <StatusBadge
+        label={item.isSynced ? 'Synced' : 'Submitted'}
+        icon={item.isSynced ? '✅' : '🟢'}
+        color={item.isSynced ? '#5cb85c' : '#0a7ea4'}
+      />
     </TouchableOpacity>
   );
 


### PR DESCRIPTION
## Summary
- show badge component for form statuses
- track sync errors and timestamps
- display status badges in Drafts, Outbox and Sent lists

## Testing
- `npm run lint` *(fails: expo not found)*
- `npm test` *(fails: missing test script)*
- `npx tsc -p tsconfig.json` *(fails: type errors, expo config missing)*

------
https://chatgpt.com/codex/tasks/task_e_6874018a75048328b37040b465c9982e