### PR TITLE
Add multi-photo support with preview

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "expo-font": "~13.3.2",
     "expo-haptics": "~14.1.4",
     "expo-image": "~2.3.2",
+    "expo-image-manipulator": "~3.4.0",
     "expo-image-picker": "16.1.4",
     "expo-linking": "~7.1.7",
     "expo-router": "~5.1.3",


### PR DESCRIPTION
## Summary
- allow photo fields to hold several images
- compress photos when capturing
- enable preview and delete actions
- expand default state handling for photo arrays
- include expo-image-manipulator dependency

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874087f50848328945237467da3b3d8