### PR TITLE
Add new form input types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@react-navigation/elements": "^2.3.8",
         "@react-navigation/native": "^7.1.6",
         "expo": "~53.0.17",
+        "expo-barcode-scanner": "^12.9.3",
         "expo-blur": "~14.1.5",
         "expo-constants": "~17.1.7",
         "expo-file-system": "~18.1.11",
@@ -41,6 +42,7 @@
         "react-native-reanimated": "~3.17.4",
         "react-native-safe-area-context": "5.4.0",
         "react-native-screens": "~4.11.1",
+        "react-native-signature-canvas": "^4.4.0",
         "react-native-web": "~0.20.0",
         "react-native-webview": "13.13.5",
         "uuid": "^9.0.0"
@@ -6265,6 +6267,27 @@
         "react-native": "*"
       }
     },
+    "node_modules/expo-barcode-scanner": {
+      "version": "12.9.3",
+      "resolved": "https://registry.npmjs.org/expo-barcode-scanner/-/expo-barcode-scanner-12.9.3.tgz",
+      "integrity": "sha512-I3zaKSINRMHbTc7sHIq14ug3fHkCsW4rweJF12yk0kHaympI2wxVgIo2DhzeZaYG1Ylkuj5aiKen3NuwDk1FSA==",
+      "license": "MIT",
+      "dependencies": {
+        "expo-image-loader": "~4.6.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-barcode-scanner/node_modules/expo-image-loader": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/expo-image-loader/-/expo-image-loader-4.6.0.tgz",
+      "integrity": "sha512-RHQTDak7/KyhWUxikn2yNzXL7i2cs16cMp6gEAgkHOjVhoCJQoOJ0Ljrt4cKQ3IowxgCuOrAgSUzGkqs7omj8Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
     "node_modules/expo-blur": {
       "version": "14.1.5",
       "resolved": "https://registry.npmjs.org/expo-blur/-/expo-blur-14.1.5.tgz",
@@ -10428,6 +10451,15 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/react-native-signature-canvas": {
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/react-native-signature-canvas/-/react-native-signature-canvas-4.7.4.tgz",
+      "integrity": "sha512-8KbZ35yS2nchunk47mQ4lz8JQyvOgLs2rOX45TzqIcFSSIsmCMvbiqLzGH0gLYNq/A5s0Xg+CupzcOfvO5pjRA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react-native-webview": ">=13"
       }
     },
     "node_modules/react-native-web": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@react-navigation/elements": "^2.3.8",
     "@react-navigation/native": "^7.1.6",
     "expo": "~53.0.17",
+    "expo-barcode-scanner": "^12.9.3",
     "expo-blur": "~14.1.5",
     "expo-constants": "~17.1.7",
     "expo-file-system": "~18.1.11",
@@ -35,7 +36,6 @@
     "expo-symbols": "~0.4.5",
     "expo-system-ui": "~5.0.10",
     "expo-web-browser": "~14.2.0",
-    "react-native-signature-canvas": "^4.4.0",
     "jwt-decode": "^3.1.2",
     "react": "19.0.0",
     "react-dom": "19.0.0",
@@ -45,6 +45,7 @@
     "react-native-reanimated": "~3.17.4",
     "react-native-safe-area-context": "5.4.0",
     "react-native-screens": "~4.11.1",
+    "react-native-signature-canvas": "^4.4.0",
     "react-native-web": "~0.20.0",
     "react-native-webview": "13.13.5",
     "uuid": "^9.0.0"


### PR DESCRIPTION
## Summary
- support decimal, currency, barcode, time, datetime and imageSelect in form renderer
- use expo-barcode-scanner for scanning barcodes
- allow selecting photos from library
- update FormField types
- add expo-barcode-scanner dependency

## Testing
- `npm run lint` *(fails: React Hook "useState" is called conditionally)*

------
https://chatgpt.com/codex/tasks/task_e_6874dc6c61f8832882531d2a1a98f067