### PR TITLE
Replace deprecated barcode scanner

### DIFF
--- a/components/formRenderer/fields/implementations/BarcodeField.tsx
+++ b/components/formRenderer/fields/implementations/BarcodeField.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { View, Text, TextInput, Button, Modal, LayoutChangeEvent } from 'react-native';
-import { BarCodeScanner } from 'expo-barcode-scanner';
+import { CameraView, requestCameraPermissionsAsync } from 'expo-camera';
 import { FormField } from '../types';
 import { styles } from '../../styles';
 
@@ -16,7 +16,7 @@ type Props = {
 export function BarcodeField({ field, value, onChange, error, readOnly, onLayout }: Props) {
   const [scanVisible, setScanVisible] = useState(false);
   const startScan = async () => {
-    const { status } = await BarCodeScanner.requestPermissionsAsync();
+    const { status } = await requestCameraPermissionsAsync();
     if (status === 'granted') {
       setScanVisible(true);
     }
@@ -35,8 +35,8 @@ export function BarcodeField({ field, value, onChange, error, readOnly, onLayout
       </View>
       {scanVisible && (
         <Modal transparent onRequestClose={() => setScanVisible(false)}>
-          <BarCodeScanner
-            onBarCodeScanned={({ data }) => {
+          <CameraView
+            onBarcodeScanned={({ data }) => {
               setScanVisible(false);
               onChange(data);
             }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,8 +17,8 @@
         "@react-navigation/elements": "^2.3.8",
         "@react-navigation/native": "^7.1.6",
         "expo": "~53.0.17",
-        "expo-barcode-scanner": "^12.9.3",
         "expo-blur": "~14.1.5",
+        "expo-camera": "^16.1.10",
         "expo-constants": "~17.1.7",
         "expo-file-system": "~18.1.11",
         "expo-font": "~13.3.2",
@@ -6268,27 +6268,6 @@
         "react-native": "*"
       }
     },
-    "node_modules/expo-barcode-scanner": {
-      "version": "12.9.3",
-      "resolved": "https://registry.npmjs.org/expo-barcode-scanner/-/expo-barcode-scanner-12.9.3.tgz",
-      "integrity": "sha512-I3zaKSINRMHbTc7sHIq14ug3fHkCsW4rweJF12yk0kHaympI2wxVgIo2DhzeZaYG1Ylkuj5aiKen3NuwDk1FSA==",
-      "license": "MIT",
-      "dependencies": {
-        "expo-image-loader": "~4.6.0"
-      },
-      "peerDependencies": {
-        "expo": "*"
-      }
-    },
-    "node_modules/expo-barcode-scanner/node_modules/expo-image-loader": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/expo-image-loader/-/expo-image-loader-4.6.0.tgz",
-      "integrity": "sha512-RHQTDak7/KyhWUxikn2yNzXL7i2cs16cMp6gEAgkHOjVhoCJQoOJ0Ljrt4cKQ3IowxgCuOrAgSUzGkqs7omj8Q==",
-      "license": "MIT",
-      "peerDependencies": {
-        "expo": "*"
-      }
-    },
     "node_modules/expo-blur": {
       "version": "14.1.5",
       "resolved": "https://registry.npmjs.org/expo-blur/-/expo-blur-14.1.5.tgz",
@@ -6298,6 +6277,26 @@
         "expo": "*",
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/expo-camera": {
+      "version": "16.1.10",
+      "resolved": "https://registry.npmjs.org/expo-camera/-/expo-camera-16.1.10.tgz",
+      "integrity": "sha512-qoRJeSwPmMbuu0VfnQTC+q79Kt2SqTWColEImgithL9u0qUQcC55U89IfhZk55Hpt6f1DgKuDzUOG5oY+snSWg==",
+      "license": "MIT",
+      "dependencies": {
+        "invariant": "^2.2.4"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*",
+        "react-native-web": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-web": {
+          "optional": true
+        }
       }
     },
     "node_modules/expo-constants": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@react-navigation/elements": "^2.3.8",
     "@react-navigation/native": "^7.1.6",
     "expo": "~53.0.17",
-    "expo-barcode-scanner": "^12.9.3",
+    "expo-camera": "^16.1.10",
     "expo-blur": "~14.1.5",
     "expo-constants": "~17.1.7",
     "expo-file-system": "~18.1.11",


### PR DESCRIPTION
## Summary
- replace BarCodeScanner with CameraView to avoid using deprecated API
- install expo-camera and remove expo-barcode-scanner

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6874f477e1588328baf472d10b5e02c5