### PR TITLE
Refactor form navigation

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,27 +1,30 @@
-import AsyncStorage from '@react-native-async-storage/async-storage';
+import AsyncStorage from "@react-native-async-storage/async-storage";
 import {
   NavigationContainer,
   DarkTheme as NavigationDarkTheme,
   DefaultTheme as NavigationDefaultTheme,
-} from '@react-navigation/native';
-import { createNativeStackNavigator } from '@react-navigation/native-stack';
-import { useEffect, useState } from 'react';
-import { ActivityIndicator, View } from 'react-native';
-import { BottomNavigation, PaperProvider } from 'react-native-paper';
+} from "@react-navigation/native";
+import { createNativeStackNavigator } from "@react-navigation/native-stack";
+import { useEffect, useState } from "react";
+import { ActivityIndicator, View } from "react-native";
+import { BottomNavigation, PaperProvider } from "react-native-paper";
 
-import { darkTheme, lightTheme } from '@/constants/theme';
-import { FormCountsProvider, useFormCounts } from '@/context/FormCountsContext';
-import { useColorScheme } from '@/hooks/useColorScheme';
-import type { DraftsStackParamList, RootStackParamList } from '@/navigation/types';
-import CreateFormScreen from '@/screens/CreateFormScreen';
-import DraftsScreen from '@/screens/DraftsScreen';
-import FormScreen from '@/screens/FormScreen';
-import InboxScreen from '@/screens/InboxScreen';
-import LoginScreen from '@/screens/LoginScreen';
-import OutboxScreen from '@/screens/OutboxScreen';
-import SentScreen from '@/screens/SentScreen';
-import SettingsScreen from '@/screens/SettingsScreen';
-import { cleanupOldSentForms } from '@/services/sentService';
+import { darkTheme, lightTheme } from "@/constants/theme";
+import { FormCountsProvider, useFormCounts } from "@/context/FormCountsContext";
+import { useColorScheme } from "@/hooks/useColorScheme";
+import type {
+  DraftsStackParamList,
+  RootStackParamList,
+} from "@/navigation/types";
+import CreateFormScreen from "@/screens/CreateFormScreen";
+import DraftsScreen from "@/screens/DraftsScreen";
+import FormScreen from "@/screens/FormScreen";
+import InboxScreen from "@/screens/InboxScreen";
+import LoginScreen from "@/screens/LoginScreen";
+import OutboxScreen from "@/screens/OutboxScreen";
+import SentScreen from "@/screens/SentScreen";
+import SettingsScreen from "@/screens/SettingsScreen";
+import { cleanupOldSentForms } from "@/services/sentService";
 
 const RootStack = createNativeStackNavigator<RootStackParamList>();
 const DraftsStack = createNativeStackNavigator<DraftsStackParamList>();
@@ -34,12 +37,6 @@ function DraftsTabNavigator() {
         component={DraftsScreen}
         options={{ headerShown: false }}
       />
-      <DraftsStack.Screen
-        name="CreateFormScreen"
-        component={CreateFormScreen}
-        options={{ title: 'Create Form' }}
-      />
-      <DraftsStack.Screen name="FormScreen" component={FormScreen} options={{ title: 'Form' }} />
     </DraftsStack.Navigator>
   );
 }
@@ -48,21 +45,21 @@ function MainTabNavigator() {
   const { counts } = useFormCounts();
   const [index, setIndex] = useState(0);
   const routes = [
-    { key: 'inbox', title: 'Inbox', focusedIcon: 'inbox', badge: counts.inbox },
+    { key: "inbox", title: "Inbox", focusedIcon: "inbox", badge: counts.inbox },
     {
-      key: 'drafts',
-      title: 'Drafts',
-      focusedIcon: 'application-edit',
+      key: "drafts",
+      title: "Drafts",
+      focusedIcon: "application-edit",
       badge: counts.drafts,
     },
     {
-      key: 'outbox',
-      title: 'Outbox',
-      focusedIcon: 'archive-sync',
+      key: "outbox",
+      title: "Outbox",
+      focusedIcon: "archive-sync",
       badge: counts.outbox,
     },
-    { key: 'sent', title: 'Sent', focusedIcon: 'send', badge: counts.sent },
-    { key: 'settings', title: 'Settings', focusedIcon: 'application-cog' },
+    { key: "sent", title: "Sent", focusedIcon: "send", badge: counts.sent },
+    { key: "settings", title: "Settings", focusedIcon: "application-cog" },
   ];
 
   const renderScene = BottomNavigation.SceneMap({
@@ -83,7 +80,6 @@ function MainTabNavigator() {
   );
 }
 
-
 export default function App() {
   const colorScheme = useColorScheme();
   const [isLoggedIn, setIsLoggedIn] = useState<boolean | null>(null);
@@ -91,8 +87,8 @@ export default function App() {
   useEffect(() => {
     async function loadStatus() {
       try {
-        const value = await AsyncStorage.getItem('auth:isLoggedIn');
-        setIsLoggedIn(value === 'true');
+        const value = await AsyncStorage.getItem("auth:isLoggedIn");
+        setIsLoggedIn(value === "true");
       } catch {
         setIsLoggedIn(false);
       }
@@ -107,38 +103,58 @@ export default function App() {
           console.log(`Cleaned up ${count} old sent forms`);
         }
       })
-      .catch((err) => console.log('Cleanup error:', err));
+      .catch((err) => console.log("Cleanup error:", err));
   }, []);
 
   if (isLoggedIn === null) {
     return (
-      <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+      <View style={{ flex: 1, justifyContent: "center", alignItems: "center" }}>
         <ActivityIndicator />
       </View>
     );
   }
-  const paperTheme = colorScheme === 'dark' ? darkTheme : lightTheme;
-  const navigationTheme = colorScheme === 'dark' ? NavigationDarkTheme : NavigationDefaultTheme;
+  const paperTheme = colorScheme === "dark" ? darkTheme : lightTheme;
+  const navigationTheme =
+    colorScheme === "dark" ? NavigationDarkTheme : NavigationDefaultTheme;
   return (
     <FormCountsProvider>
       <PaperProvider theme={paperTheme}>
-      <NavigationContainer theme={{...navigationTheme, colors: { ...navigationTheme.colors, background: paperTheme.colors.background }}}>
-        <RootStack.Navigator
-          screenOptions={{ headerShown: false }}
-          initialRouteName={isLoggedIn ? 'MainTabs' : 'Login'}>
-        <RootStack.Screen name="Login">
-          {(props) => (
-            <LoginScreen {...props} onLogin={() => setIsLoggedIn(true)} />
-          )}
-        </RootStack.Screen>
-        <RootStack.Screen
-          name="MainTabs"
-          component={MainTabNavigator}
-          options={{ headerShown: false }}
-        />
-      </RootStack.Navigator>
-    </NavigationContainer>
-    </PaperProvider>
+        <NavigationContainer
+          theme={{
+            ...navigationTheme,
+            colors: {
+              ...navigationTheme.colors,
+              background: paperTheme.colors.background,
+            },
+          }}
+        >
+          <RootStack.Navigator
+            screenOptions={{ headerShown: false }}
+            initialRouteName={isLoggedIn ? "MainTabs" : "Login"}
+          >
+            <RootStack.Screen name="Login">
+              {(props) => (
+                <LoginScreen {...props} onLogin={() => setIsLoggedIn(true)} />
+              )}
+            </RootStack.Screen>
+            <RootStack.Screen
+              name="MainTabs"
+              component={MainTabNavigator}
+              options={{ headerShown: false }}
+            />
+            <RootStack.Screen
+              name="CreateFormScreen"
+              component={CreateFormScreen}
+              options={{ title: "Create Form" }}
+            />
+            <RootStack.Screen
+              name="FormScreen"
+              component={FormScreen}
+              options={{ title: "Form" }}
+            />
+          </RootStack.Navigator>
+        </NavigationContainer>
+      </PaperProvider>
     </FormCountsProvider>
   );
 }

--- a/navigation/types.ts
+++ b/navigation/types.ts
@@ -1,17 +1,8 @@
-import type { NavigatorScreenParams } from '@react-navigation/native';
-import type { FormSchema } from '@/components/formRenderer/fields/types';
+import type { NavigatorScreenParams } from "@react-navigation/native";
+import type { FormSchema } from "@/components/formRenderer/fields/types";
 
 export type DraftsStackParamList = {
   DraftsScreen: undefined;
-  CreateFormScreen: undefined;
-  FormScreen: {
-    schema: FormSchema;
-    formType?: string;
-    formName?: string;
-    data?: Record<string, any>;
-    draftId?: string;
-    readOnly?: boolean;
-  };
 };
 
 export type MainTabParamList = {
@@ -25,4 +16,13 @@ export type MainTabParamList = {
 export type RootStackParamList = {
   Login: undefined;
   MainTabs: NavigatorScreenParams<MainTabParamList> | undefined;
+  CreateFormScreen: undefined;
+  FormScreen: {
+    schema: FormSchema;
+    formType?: string;
+    formName?: string;
+    data?: Record<string, any>;
+    draftId?: string;
+    readOnly?: boolean;
+  };
 };

--- a/screens/CreateFormScreen.tsx
+++ b/screens/CreateFormScreen.tsx
@@ -1,6 +1,6 @@
-import { useNavigation } from '@react-navigation/native';
-import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
-import { useEffect, useState } from 'react';
+import { useNavigation } from "@react-navigation/native";
+import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
+import { useEffect, useState } from "react";
 import {
   Button,
   KeyboardAvoidingView,
@@ -10,26 +10,26 @@ import {
   StyleSheet,
   TextInput,
   View,
-} from 'react-native';
-import DropDownPicker from 'react-native-dropdown-picker';
+} from "react-native";
+import DropDownPicker from "react-native-dropdown-picker";
 
-import type { FormSchema } from '@/components/formRenderer/fields/types';
-import { ThemedText } from '@/components/ThemedText';
-import { Colors } from '@/constants/Colors';
-import { useColorScheme } from '@/hooks/useColorScheme';
-import { DraftsStackParamList } from '@/navigation/types';
+import type { FormSchema } from "@/components/formRenderer/fields/types";
+import { ThemedText } from "@/components/ThemedText";
+import { Colors } from "@/constants/Colors";
+import { useColorScheme } from "@/hooks/useColorScheme";
+import { RootStackParamList } from "@/navigation/types";
 import {
   getFormTemplates,
   type FormTemplate,
-} from '@/services/formTemplateService';
+} from "@/services/formTemplateService";
 
 export default function CreateFormScreen() {
   const navigation =
-    useNavigation<NativeStackNavigationProp<DraftsStackParamList>>();
-  const colorScheme = useColorScheme() ?? 'light';
-  const [formName, setFormName] = useState('');
+    useNavigation<NativeStackNavigationProp<RootStackParamList>>();
+  const colorScheme = useColorScheme() ?? "light";
+  const [formName, setFormName] = useState("");
   const [templates, setTemplates] = useState<FormTemplate[]>([]);
-  const [formType, setFormType] = useState<string>('');
+  const [formType, setFormType] = useState<string>("");
   const [schema, setSchema] = useState<FormSchema | null>(null);
   const [open, setOpen] = useState(false);
 
@@ -42,7 +42,7 @@ export default function CreateFormScreen() {
           setSchema(data[0].schema);
         }
       })
-      .catch((err) => console.log('Error loading form templates', err));
+      .catch((err) => console.log("Error loading form templates", err));
   }, []);
 
   useEffect(() => {
@@ -52,19 +52,16 @@ export default function CreateFormScreen() {
     }
   }, [formType, templates]);
 
-
-  
-
   const handleStart = () => {
     if (!schema) return;
-    navigation.navigate('FormScreen', { schema, formType, formName });
+    navigation.navigate("FormScreen", { schema, formType, formName });
   };
 
   return (
     <SafeAreaView style={{ flex: 1 }}>
       <KeyboardAvoidingView
         style={{ flex: 1 }}
-        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+        behavior={Platform.OS === "ios" ? "padding" : "height"}
         keyboardVerticalOffset={80}
       >
         <ScrollView
@@ -118,16 +115,16 @@ const styles = StyleSheet.create({
   },
   textInput: {
     borderWidth: 1,
-    borderColor: '#ccc',
+    borderColor: "#ccc",
     padding: 8,
     borderRadius: 4,
   },
   dropdown: {
     borderWidth: 1,
-    borderColor: '#ccc',
+    borderColor: "#ccc",
   },
   dropdownContainer: {
     borderWidth: 1,
-    borderColor: '#ccc',
+    borderColor: "#ccc",
   },
 });

--- a/screens/DraftsScreen.tsx
+++ b/screens/DraftsScreen.tsx
@@ -1,35 +1,29 @@
-import AsyncStorage from '@react-native-async-storage/async-storage';
-import { useFocusEffect, useNavigation } from '@react-navigation/native';
-import * as FileSystem from 'expo-file-system';
-import { useCallback, useState } from 'react';
-import {
-  Alert,
-  FlatList,
-  StyleSheet,
-  View,
-} from 'react-native';
-import { Card, FAB, IconButton, TextInput } from 'react-native-paper';
-import { SafeAreaView } from 'react-native-safe-area-context';
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { useFocusEffect, useNavigation } from "@react-navigation/native";
+import * as FileSystem from "expo-file-system";
+import { useCallback, useState } from "react";
+import { Alert, FlatList, StyleSheet, View } from "react-native";
+import { Card, FAB, IconButton, TextInput } from "react-native-paper";
+import { SafeAreaView } from "react-native-safe-area-context";
 
-import { ThemedText } from '@/components/ThemedText';
-import { ThemedView } from '@/components/ThemedView';
-import { spacing } from '@/constants/styles';
-import { useFormCounts } from '@/context/FormCountsContext';
-import { DraftsStackParamList } from '@/navigation/types';
+import { ThemedText } from "@/components/ThemedText";
+import { ThemedView } from "@/components/ThemedView";
+import { spacing } from "@/constants/styles";
+import { useFormCounts } from "@/context/FormCountsContext";
+import { RootStackParamList } from "@/navigation/types";
 import {
   getAllDrafts,
   getDraftById,
   type DraftForm,
-} from '@/services/draftService';
-import { deleteLocalPhoto } from '@/services/photoService';
-import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
+} from "@/services/draftService";
+import { deleteLocalPhoto } from "@/services/photoService";
+import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
 
 export default function DraftsScreen() {
-  const navigation = useNavigation<
-    NativeStackNavigationProp<DraftsStackParamList>
-  >();
+  const navigation =
+    useNavigation<NativeStackNavigationProp<RootStackParamList>>();
   const [drafts, setDrafts] = useState<DraftForm[]>([]);
-  const [searchQuery, setSearchQuery] = useState('');
+  const [searchQuery, setSearchQuery] = useState("");
   const { setCounts } = useFormCounts();
 
   const loadDrafts = useCallback(async () => {
@@ -45,7 +39,7 @@ export default function DraftsScreen() {
   );
 
   const handleResume = (draft: DraftForm) => {
-    navigation.navigate('FormScreen', {
+    navigation.navigate("FormScreen", {
       schema: draft.schema,
       formType: draft.formType,
       formName: draft.name,
@@ -56,13 +50,13 @@ export default function DraftsScreen() {
 
   const collectImageUris = (obj: any): string[] => {
     if (!obj) return [];
-    if (typeof obj === 'string') {
+    if (typeof obj === "string") {
       return obj.startsWith(FileSystem.documentDirectory) ? [obj] : [];
     }
     if (Array.isArray(obj)) {
       return obj.flatMap((i) => collectImageUris(i));
     }
-    if (typeof obj === 'object') {
+    if (typeof obj === "object") {
       return Object.values(obj).flatMap((v) => collectImageUris(v));
     }
     return [];
@@ -78,30 +72,28 @@ export default function DraftsScreen() {
 
       await AsyncStorage.removeItem(`drafts:${id}`);
       await AsyncStorage.removeItem(`draft:${id}`);
-      const indexRaw = await AsyncStorage.getItem('drafts:index');
+      const indexRaw = await AsyncStorage.getItem("drafts:index");
       const index = indexRaw ? (JSON.parse(indexRaw) as string[]) : [];
       const newIndex = index.filter((d) => d !== id);
-      await AsyncStorage.setItem('drafts:index', JSON.stringify(newIndex));
+      await AsyncStorage.setItem("drafts:index", JSON.stringify(newIndex));
       await loadDrafts();
     } catch (err) {
-      console.log('Error deleting draft:', err);
-      Alert.alert('Error', 'Failed to delete draft.');
+      console.log("Error deleting draft:", err);
+      Alert.alert("Error", "Failed to delete draft.");
     }
   };
 
   const confirmDelete = (id: string) => {
-    Alert.alert('Delete Draft', 'Are you sure you want to delete this draft?', [
-      { text: 'Cancel', style: 'cancel' },
-      { text: 'Delete', style: 'destructive', onPress: () => handleDelete(id) },
+    Alert.alert("Delete Draft", "Are you sure you want to delete this draft?", [
+      { text: "Cancel", style: "cancel" },
+      { text: "Delete", style: "destructive", onPress: () => handleDelete(id) },
     ]);
   };
 
   const filteredDrafts = drafts.filter((d) => {
     const q = searchQuery.toLowerCase();
     const address =
-      typeof d.data?.address === 'string'
-        ? d.data.address.toLowerCase()
-        : '';
+      typeof d.data?.address === "string" ? d.data.address.toLowerCase() : "";
     const matchesQuery =
       d.name.toLowerCase().includes(q) ||
       d.formType.toLowerCase().includes(q) ||
@@ -133,7 +125,8 @@ export default function DraftsScreen() {
       <Card.Content>
         <ThemedText>Form Type: {item.formType}</ThemedText>
         <ThemedText style={styles.dateText}>
-          Date Created: {new Date(item.createdAt).toLocaleDateString()} {new Date(item.createdAt).toLocaleTimeString()}
+          Date Created: {new Date(item.createdAt).toLocaleDateString()}{" "}
+          {new Date(item.createdAt).toLocaleTimeString()}
         </ThemedText>
       </Card.Content>
     </Card>
@@ -157,7 +150,9 @@ export default function DraftsScreen() {
         keyExtractor={(item) => item.id}
         renderItem={renderItem}
         contentContainerStyle={
-          filteredDrafts.length === 0 ? styles.emptyContainer : styles.listContainer
+          filteredDrafts.length === 0
+            ? styles.emptyContainer
+            : styles.listContainer
         }
         ListEmptyComponent={
           <ThemedView style={styles.emptyContainer}>
@@ -168,7 +163,7 @@ export default function DraftsScreen() {
       <FAB
         icon="plus"
         style={styles.fab}
-        onPress={() => navigation.navigate('CreateFormScreen')}
+        onPress={() => navigation.navigate("CreateFormScreen")}
         accessibilityLabel="Create New Form"
       />
     </SafeAreaView>
@@ -184,14 +179,14 @@ const styles = StyleSheet.create({
     marginBottom: spacing.sm,
   },
   fab: {
-    position: 'absolute',
+    position: "absolute",
     bottom: 40,
     right: 32,
     width: 56,
     height: 56,
     borderRadius: 28,
-    alignItems: 'center',
-    justifyContent: 'center',
+    alignItems: "center",
+    justifyContent: "center",
     elevation: 2,
   },
   listContainer: {
@@ -200,21 +195,21 @@ const styles = StyleSheet.create({
   },
   emptyContainer: {
     flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
+    justifyContent: "center",
+    alignItems: "center",
   },
   draftItem: {
     marginBottom: spacing.sm,
   },
   draftHeader: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
   },
   editButtons: {
-    flexDirection: 'row',
-    justifyContent: 'flex-end',
-    alignItems: 'flex-end',
+    flexDirection: "row",
+    justifyContent: "flex-end",
+    alignItems: "flex-end",
   },
   dateText: {
     marginBottom: 8,

--- a/screens/FormScreen.tsx
+++ b/screens/FormScreen.tsx
@@ -1,6 +1,6 @@
-import AsyncStorage from '@react-native-async-storage/async-storage';
-import { NativeStackScreenProps } from '@react-navigation/native-stack';
-import { useEffect, useRef, useState } from 'react';
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { NativeStackScreenProps } from "@react-navigation/native-stack";
+import { useEffect, useRef, useState } from "react";
 import {
   Alert,
   Button,
@@ -11,50 +11,74 @@ import {
   ScrollView,
   StyleSheet,
   TouchableOpacity,
-  View
-} from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
-import { v4 as uuidv4 } from 'uuid';
+  View,
+} from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { v4 as uuidv4 } from "uuid";
 
-import FormRenderer, { type FormRendererRef } from '@/components/formRenderer';
-import { ThemedText } from '@/components/ThemedText';
-import { ThemedView } from '@/components/ThemedView';
-import { IconSymbol } from '@/components/ui/IconSymbol';
-import { Colors } from '@/constants/Colors';
-import { useColorScheme } from '@/hooks/useColorScheme';
-import { useNetworkStatus } from '@/hooks/useNetworkStatus';
-import { DraftsStackParamList } from '@/navigation/types';
+import FormRenderer, { type FormRendererRef } from "@/components/formRenderer";
+import { ThemedText } from "@/components/ThemedText";
+import { ThemedView } from "@/components/ThemedView";
+import { IconSymbol } from "@/components/ui/IconSymbol";
+import { Colors } from "@/constants/Colors";
+import { useColorScheme } from "@/hooks/useColorScheme";
+import { useNetworkStatus } from "@/hooks/useNetworkStatus";
+import { RootStackParamList } from "@/navigation/types";
 import {
   getDraftById,
   saveDraft,
   type DraftForm,
-} from '@/services/draftService';
-import React from 'react';
+} from "@/services/draftService";
+import React from "react";
 
-type OutboxForm = Omit<DraftForm, 'status'> & {
-  status: 'complete';
+type OutboxForm = Omit<DraftForm, "status"> & {
+  status: "complete";
   syncError?: string;
   syncedAt?: string;
 };
 
-type Props = NativeStackScreenProps<DraftsStackParamList, 'FormScreen'>;
+type Props = NativeStackScreenProps<RootStackParamList, "FormScreen">;
 
 export default function FormScreen({ route, navigation }: Props) {
   const {
     schema,
     formName,
-    formType = 'demo',
+    formType = "demo",
     draftId,
     data,
     readOnly = false,
   } = route.params;
   const formRef = useRef<FormRendererRef>(null);
-  const colorScheme = useColorScheme() ?? 'light';
+  const colorScheme = useColorScheme() ?? "light";
   const isOnline = useNetworkStatus();
   const [existingDraft, setExistingDraft] = useState<DraftForm | null>(null);
-  const [initialData, setInitialData] = useState<Record<string, any> | undefined>(data);
+  const [initialData, setInitialData] = useState<
+    Record<string, any> | undefined
+  >(data);
   const [menuVisible, setMenuVisible] = useState(false);
-  const [menuTab, setMenuTab] = useState<'sections' | 'media'>('sections');
+  const [menuTab, setMenuTab] = useState<"sections" | "media">("sections");
+  const allowExitRef = useRef(false);
+
+  useEffect(() => {
+    const sub = navigation.addListener("beforeRemove", (e) => {
+      if (allowExitRef.current || readOnly) {
+        return;
+      }
+      e.preventDefault();
+      Alert.alert("Exit Form", "Discard this form and go back?", [
+        { text: "Cancel", style: "cancel" },
+        {
+          text: "Discard",
+          style: "destructive",
+          onPress: () => {
+            allowExitRef.current = true;
+            navigation.dispatch(e.data.action);
+          },
+        },
+      ]);
+    });
+    return sub;
+  }, [navigation, readOnly]);
 
   useEffect(() => {
     if (draftId) {
@@ -80,11 +104,11 @@ export default function FormScreen({ route, navigation }: Props) {
     } else {
       draft = {
         id: uuidv4(),
-        name: formName ?? 'Untitled Form',
+        name: formName ?? "Untitled Form",
         formType,
         schema,
         data,
-        status: 'draft',
+        status: "draft",
         isSynced: false,
         createdAt: timestamp,
         updatedAt: timestamp,
@@ -98,7 +122,7 @@ export default function FormScreen({ route, navigation }: Props) {
     try {
       const validation = formRef.current?.validateForm();
       if (validation && !validation.isValid) {
-        Alert.alert('Validation Error', 'Please fill all required fields.');
+        Alert.alert("Validation Error", "Please fill all required fields.");
         return;
       }
       const formData = formRef.current?.getFormData() ?? {};
@@ -111,10 +135,10 @@ export default function FormScreen({ route, navigation }: Props) {
         try {
           const loaded = await getDraftById(currentDraftId);
           if (loaded) {
-            draft = { ...loaded, status: 'complete' } as OutboxForm;
+            draft = { ...loaded, status: "complete" } as OutboxForm;
           }
         } catch (err) {
-          console.log('Error loading draft:', err);
+          console.log("Error loading draft:", err);
         }
       }
 
@@ -122,11 +146,11 @@ export default function FormScreen({ route, navigation }: Props) {
         id = uuidv4();
         draft = {
           id,
-          name: formName ?? 'Untitled Form',
+          name: formName ?? "Untitled Form",
           formType,
           schema,
           data: formData,
-          status: 'complete',
+          status: "complete",
           isSynced: false,
           syncError: undefined,
           syncedAt: undefined,
@@ -137,7 +161,7 @@ export default function FormScreen({ route, navigation }: Props) {
         draft = {
           ...draft,
           data: formData,
-          status: 'complete',
+          status: "complete",
           syncError: undefined,
           syncedAt: undefined,
           updatedAt: timestamp,
@@ -153,40 +177,43 @@ export default function FormScreen({ route, navigation }: Props) {
 
       // update outbox index
       try {
-        const outboxRaw = await AsyncStorage.getItem('outbox:index');
+        const outboxRaw = await AsyncStorage.getItem("outbox:index");
         const outbox = outboxRaw ? (JSON.parse(outboxRaw) as string[]) : [];
         if (!outbox.includes(id)) {
           outbox.push(id);
-          await AsyncStorage.setItem('outbox:index', JSON.stringify(outbox));
+          await AsyncStorage.setItem("outbox:index", JSON.stringify(outbox));
         }
       } catch (err) {
-        console.log('Error updating outbox index:', err);
+        console.log("Error updating outbox index:", err);
       }
 
       if (currentDraftId) {
         // remove draft storage and index
         try {
           await AsyncStorage.removeItem(`draft:${currentDraftId}`);
-          const indexRaw = await AsyncStorage.getItem('drafts:index');
+          const indexRaw = await AsyncStorage.getItem("drafts:index");
           const index = indexRaw ? (JSON.parse(indexRaw) as string[]) : [];
           const newIndex = index.filter((d) => d !== currentDraftId);
-          await AsyncStorage.setItem('drafts:index', JSON.stringify(newIndex));
+          await AsyncStorage.setItem("drafts:index", JSON.stringify(newIndex));
         } catch (err) {
-          console.log('Error removing draft from storage:', err);
+          console.log("Error removing draft from storage:", err);
         }
       }
 
-      console.log('Form moved to outbox:', id);
-      navigation.popToTop();
+      console.log("Form moved to outbox:", id);
+      allowExitRef.current = true;
+      navigation.goBack();
     } catch (err) {
-      console.log('Error submitting form:', err);
-      Alert.alert('Error', 'Failed to submit form.');
+      console.log("Error submitting form:", err);
+      Alert.alert("Error", "Failed to submit form.");
     }
   };
 
   const sectionEntries = schema.flatMap((section) => {
     if (section.repeatable) {
-      const dataArr = formRef.current?.getFormData()[section.key] as any[] | undefined;
+      const dataArr = formRef.current?.getFormData()[section.key] as
+        | any[]
+        | undefined;
       const length = dataArr ? dataArr.length : 0;
       return Array.from({ length }).map((_, idx) => ({
         key: `${section.key}.${idx}`,
@@ -210,175 +237,185 @@ export default function FormScreen({ route, navigation }: Props) {
   };
 
   return (
-      <ThemedView style={{ flex: 1 }}>
-        <KeyboardAvoidingView
-          style={{ flex: 1 }}
-          behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
-          keyboardVerticalOffset={80}
-        >
-          <View style={styles.buttonRow}>
-            <View style={styles.buttonWrapper}>
-              <Button title="Back" onPress={() => navigation.popToTop()} />
-            </View>
-            {!readOnly && (
-              <>
-                <View style={styles.buttonWrapper}>
-                  <Button title="Save" onPress={handleSaveDraft} />
-                </View>
-                <View style={styles.buttonWrapper}>
-                  <Button
-                    title="Submit"
-                    onPress={handleSubmitForm}
-                    color={Colors[colorScheme].tint}
-                    disabled={!isOnline}
-                  />
-                </View>
-              </>
-            )}
-            <TouchableOpacity onPress={() => setMenuVisible(true)}>
-                  <IconSymbol
-                    name="line.3.horizontal"
-                    size={24}
-                    color={Colors[colorScheme].text}
-                  />
-                </TouchableOpacity>
+    <ThemedView style={{ flex: 1 }}>
+      <KeyboardAvoidingView
+        style={{ flex: 1 }}
+        behavior={Platform.OS === "ios" ? "padding" : "height"}
+        keyboardVerticalOffset={80}
+      >
+        <View style={styles.buttonRow}>
+          <View style={styles.buttonWrapper}>
+            <Button title="Back" onPress={() => navigation.goBack()} />
           </View>
-          <ScrollView
-            contentContainerStyle={styles.contentContainer}
-            keyboardShouldPersistTaps="handled"
-          >
-              <View style={styles.header}>
-                <ThemedText style={styles.title}>
-                  Title: {formName}
-                </ThemedText>
+          {!readOnly && (
+            <>
+              <View style={styles.buttonWrapper}>
+                <Button title="Save" onPress={handleSaveDraft} />
               </View>
-
-            {!isOnline && (
-              <ThemedText style={styles.offlineText}>
-                You are offline. Submissions are disabled.
-              </ThemedText>
-            )}
-            <FormRenderer
-              ref={formRef}
-              schema={schema}
-              initialData={initialData}
-              readOnly={readOnly}
+              <View style={styles.buttonWrapper}>
+                <Button
+                  title="Submit"
+                  onPress={handleSubmitForm}
+                  color={Colors[colorScheme].tint}
+                  disabled={!isOnline}
+                />
+              </View>
+            </>
+          )}
+          <TouchableOpacity onPress={() => setMenuVisible(true)}>
+            <IconSymbol
+              name="line.3.horizontal"
+              size={24}
+              color={Colors[colorScheme].text}
             />
-          </ScrollView>
-        </KeyboardAvoidingView>
-        <Modal
-          transparent
-          animationType="slide"
-          visible={menuVisible}
-          onRequestClose={() => setMenuVisible(false)}
+          </TouchableOpacity>
+        </View>
+        <ScrollView
+          contentContainerStyle={styles.contentContainer}
+          keyboardShouldPersistTaps="handled"
         >
-          <SafeAreaView style={styles.modalOverlay}>
-            <View
-              style={[styles.drawer, { backgroundColor: Colors[colorScheme].background }]}
-            >
-              <View style={styles.tabRow}>
-                <TouchableOpacity
-                  style={[styles.tabButton, menuTab === 'sections' && styles.activeTab]}
-                  onPress={() => setMenuTab('sections')}
-                >
-                  <ThemedText>Sections</ThemedText>
-                </TouchableOpacity>
-                <TouchableOpacity
-                  style={[styles.tabButton, menuTab === 'media' && styles.activeTab]}
-                  onPress={() => setMenuTab('media')}
-                >
-                  <ThemedText>Media</ThemedText>
-                </TouchableOpacity>
-              </View>
-              {menuTab === 'sections' ? (
-                <ScrollView>
-                  {sectionEntries.map((item) => (
-                    <TouchableOpacity
-                      key={item.key}
-                      style={styles.menuItem}
-                      onPress={() => handleSectionPress(item.key)}
-                    >
-                      <ThemedText>{item.label}</ThemedText>
-                      {sectionErrors[item.key] && (
-                        <IconSymbol
-                          name="exclamationmark.circle.fill"
-                          size={16}
-                          color="red"
-                        />
-                      )}
-                    </TouchableOpacity>
-                  ))}
-                </ScrollView>
-              ) : (
-                <ScrollView contentContainerStyle={styles.mediaList}>
-                  {photos.map((p) => (
-                    <TouchableOpacity key={p.key} onPress={() => handleMediaPress(p.key)}>
-                      <Image source={{ uri: p.uri }} style={styles.mediaThumb} />
-                    </TouchableOpacity>
-                  ))}
-                </ScrollView>
-              )}
+          <View style={styles.header}>
+            <ThemedText style={styles.title}>Title: {formName}</ThemedText>
+          </View>
+
+          {!isOnline && (
+            <ThemedText style={styles.offlineText}>
+              You are offline. Submissions are disabled.
+            </ThemedText>
+          )}
+          <FormRenderer
+            ref={formRef}
+            schema={schema}
+            initialData={initialData}
+            readOnly={readOnly}
+          />
+        </ScrollView>
+      </KeyboardAvoidingView>
+      <Modal
+        transparent
+        animationType="slide"
+        visible={menuVisible}
+        onRequestClose={() => setMenuVisible(false)}
+      >
+        <SafeAreaView style={styles.modalOverlay}>
+          <View
+            style={[
+              styles.drawer,
+              { backgroundColor: Colors[colorScheme].background },
+            ]}
+          >
+            <View style={styles.tabRow}>
+              <TouchableOpacity
+                style={[
+                  styles.tabButton,
+                  menuTab === "sections" && styles.activeTab,
+                ]}
+                onPress={() => setMenuTab("sections")}
+              >
+                <ThemedText>Sections</ThemedText>
+              </TouchableOpacity>
+              <TouchableOpacity
+                style={[
+                  styles.tabButton,
+                  menuTab === "media" && styles.activeTab,
+                ]}
+                onPress={() => setMenuTab("media")}
+              >
+                <ThemedText>Media</ThemedText>
+              </TouchableOpacity>
             </View>
-          </SafeAreaView>
-        </Modal>
-      </ThemedView>
+            {menuTab === "sections" ? (
+              <ScrollView>
+                {sectionEntries.map((item) => (
+                  <TouchableOpacity
+                    key={item.key}
+                    style={styles.menuItem}
+                    onPress={() => handleSectionPress(item.key)}
+                  >
+                    <ThemedText>{item.label}</ThemedText>
+                    {sectionErrors[item.key] && (
+                      <IconSymbol
+                        name="exclamationmark.circle.fill"
+                        size={16}
+                        color="red"
+                      />
+                    )}
+                  </TouchableOpacity>
+                ))}
+              </ScrollView>
+            ) : (
+              <ScrollView contentContainerStyle={styles.mediaList}>
+                {photos.map((p) => (
+                  <TouchableOpacity
+                    key={p.key}
+                    onPress={() => handleMediaPress(p.key)}
+                  >
+                    <Image source={{ uri: p.uri }} style={styles.mediaThumb} />
+                  </TouchableOpacity>
+                ))}
+              </ScrollView>
+            )}
+          </View>
+        </SafeAreaView>
+      </Modal>
+    </ThemedView>
   );
 }
 
 const styles = StyleSheet.create({
   header: {
-    flexDirection: 'row',
-    alignItems: 'center',
+    flexDirection: "row",
+    alignItems: "center",
     padding: 16,
   },
   title: {
-    fontWeight: 'bold',
-    flex: 1
+    fontWeight: "bold",
+    flex: 1,
   },
   contentContainer: {
     padding: 16,
   },
   buttonRow: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
+    flexDirection: "row",
+    justifyContent: "space-between",
     gap: 8,
-    padding: 16
+    padding: 16,
   },
   buttonWrapper: {
     flex: 1,
   },
   modalOverlay: {
     flex: 1,
-    backgroundColor: 'rgba(0,0,0,0.3)',
-    flexDirection: 'row',
-    justifyContent: 'flex-end',
+    backgroundColor: "rgba(0,0,0,0.3)",
+    flexDirection: "row",
+    justifyContent: "flex-end",
   },
   drawer: {
     width: 250,
     padding: 16,
   },
   tabRow: {
-    flexDirection: 'row',
+    flexDirection: "row",
     marginBottom: 8,
   },
   tabButton: {
     flex: 1,
-    alignItems: 'center',
+    alignItems: "center",
     paddingVertical: 8,
   },
   activeTab: {
     borderBottomWidth: 2,
-    borderColor: '#0a7ea4',
+    borderColor: "#0a7ea4",
   },
   menuItem: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
     paddingVertical: 12,
   },
   mediaList: {
-    flexDirection: 'row',
-    flexWrap: 'wrap',
+    flexDirection: "row",
+    flexWrap: "wrap",
     gap: 8,
   },
   mediaThumb: {
@@ -387,8 +424,8 @@ const styles = StyleSheet.create({
     borderRadius: 4,
   },
   offlineText: {
-    color: 'red',
-    textAlign: 'center',
+    color: "red",
+    textAlign: "center",
     marginBottom: 8,
   },
 });


### PR DESCRIPTION
## Summary
- move form views out of the drafts tab stack
- expose form screens on the root navigator
- update drafts screen navigation calls
- update form screen to confirm when exiting
- keep back buttons on form and form creation screens

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'uuid' and other type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68769cf3310083288bfa40cc1046fc14