### PR TITLE
Refactor multiselect field to use dropdown modal

### DIFF
--- a/components/formRenderer/fields/implementations/MultiSelectField.tsx
+++ b/components/formRenderer/fields/implementations/MultiSelectField.tsx
@@ -1,8 +1,21 @@
-import React from 'react';
-import { View, Text, LayoutChangeEvent } from 'react-native';
-import { Switch } from 'react-native-paper';
+import React, { useMemo, useState } from 'react';
+import {
+  View,
+  Text,
+  Modal,
+  TouchableOpacity,
+  ScrollView,
+  StyleSheet,
+  LayoutChangeEvent,
+} from 'react-native';
+import { TextInput, Checkbox, Button } from 'react-native-paper';
 import { FormField } from '../types';
-import { styles } from '../../styles';
+import { styles as formStyles } from '../../styles';
+
+interface Option {
+  label: string;
+  value: string;
+}
 
 type Props = {
   field: Extract<FormField, { type: 'multiselect' }>;
@@ -14,32 +27,92 @@ type Props = {
 };
 
 export function MultiSelectField({ field, value, onChange, error, readOnly, onLayout }: Props) {
+  const [visible, setVisible] = useState(false);
+
+  const options: Option[] = useMemo(
+    () =>
+      field.options.map((o) =>
+        typeof o === 'string' ? { label: o, value: o } : o,
+      ),
+    [field.options],
+  );
+
+  const selectedLabels = useMemo(
+    () =>
+      options
+        .filter((o) => value.includes(o.value))
+        .map((o) => o.label)
+        .join(', '),
+    [options, value],
+  );
+
+  const toggleValue = (val: string) => {
+    if (readOnly) return;
+    const current = Array.isArray(value) ? [...value] : [];
+    if (current.includes(val)) {
+      onChange(current.filter((v) => v !== val));
+    } else {
+      onChange([...current, val]);
+    }
+  };
+
   return (
-    <View style={[styles.fieldContainer, error && styles.errorContainer]} onLayout={onLayout}>
-      <Text style={styles.label}>{field.label}</Text>
-      {field.options.map((opt) => {
-        const selected = Array.isArray(value) ? value.includes(opt) : false;
-        return (
-          <View key={opt} style={{ flexDirection: 'row', alignItems: 'center', gap: 8 }}>
-            <Switch
-              value={selected}
-              onValueChange={(val) => {
-                const current: string[] = Array.isArray(value) ? [...value] : [];
-                if (val) {
-                  if (!current.includes(opt)) current.push(opt);
-                } else {
-                  const idx = current.indexOf(opt);
-                  if (idx > -1) current.splice(idx, 1);
-                }
-                onChange(current);
-              }}
-              disabled={readOnly}
-            />
-            <Text>{opt}</Text>
-          </View>
-        );
-      })}
-      {error && <Text style={styles.errorText}>{error}</Text>}
+    <View style={[formStyles.fieldContainer, error && formStyles.errorContainer]} onLayout={onLayout}>
+      <Text style={formStyles.label}>{field.label}</Text>
+      <TouchableOpacity activeOpacity={0.8} onPress={() => !readOnly && setVisible(true)}>
+        <TextInput
+          pointerEvents="none"
+          editable={false}
+          value={selectedLabels}
+          mode="outlined"
+          style={[formStyles.textInput, error && formStyles.errorInput, formStyles.formTextInput]}
+        />
+      </TouchableOpacity>
+      {error && <Text style={formStyles.errorText}>{error}</Text>}
+      <Modal transparent animationType="fade" visible={visible} onRequestClose={() => setVisible(false)}>
+        <TouchableOpacity style={modalStyles.backdrop} activeOpacity={1} onPress={() => setVisible(false)}>
+          <TouchableOpacity style={modalStyles.container} activeOpacity={1}>
+            <ScrollView>
+              {options.map((opt) => (
+                <TouchableOpacity
+                  key={opt.value}
+                  style={modalStyles.option}
+                  onPress={() => toggleValue(opt.value)}
+                  disabled={readOnly}
+                >
+                  <Checkbox status={value.includes(opt.value) ? 'checked' : 'unchecked'} />
+                  <Text>{opt.label}</Text>
+                </TouchableOpacity>
+              ))}
+            </ScrollView>
+            <Button mode="contained" onPress={() => setVisible(false)} style={modalStyles.doneButton}>
+              Done
+            </Button>
+          </TouchableOpacity>
+        </TouchableOpacity>
+      </Modal>
     </View>
   );
 }
+
+const modalStyles = StyleSheet.create({
+  backdrop: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.5)',
+    justifyContent: 'center',
+    padding: 32,
+  },
+  container: {
+    backgroundColor: 'white',
+    padding: 16,
+    borderRadius: 4,
+    maxHeight: '80%',
+  },
+  option: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  doneButton: {
+    marginTop: 8,
+  },
+});

--- a/components/formRenderer/fields/types.ts
+++ b/components/formRenderer/fields/types.ts
@@ -57,7 +57,7 @@ export type FormField =
       type: 'multiselect';
       label: string;
       key: string;
-      options: string[];
+      options: string[] | { label: string; value: string }[];
       required?: boolean;
       visibleWhen?: VisibleWhen;
     };


### PR DESCRIPTION
## Summary
- support object options in form field types
- replace toggle list multiselect with modal-based dropdown

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687a5e239c0883289ce3f5f133ee4bde