### PR TITLE
Add embedded form screen

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -9,6 +9,7 @@ import { useEffect, useRef, useState } from "react";
 import { ActivityIndicator, View, Modal, StyleSheet, Text } from "react-native";
 import { BottomNavigation, PaperProvider, Button } from "react-native-paper";
 import NetInfo from "@react-native-community/netinfo";
+import * as Linking from "expo-linking";
 import * as SecureStore from "expo-secure-store";
 import jwtDecode from "jwt-decode";
 
@@ -28,6 +29,7 @@ import OutboxScreen from "@/screens/OutboxScreen";
 import SentScreen from "@/screens/SentScreen";
 import SettingsScreen from "@/screens/SettingsScreen";
 import { cleanupOldSentForms } from "@/services/sentService";
+import EmbeddedFormScreen from "@/screens/EmbeddedFormScreen";
 
 const RootStack = createNativeStackNavigator<RootStackParamList>();
 const DraftsStack = createNativeStackNavigator<DraftsStackParamList>();
@@ -146,6 +148,15 @@ export default function App() {
     setIsLoggedIn(false);
   };
 
+  const linking = {
+    prefixes: [Linking.createURL('/')],
+    config: {
+      screens: {
+        EmbeddedFormScreen: 'embedded-form',
+      },
+    },
+  };
+
   useEffect(() => {
     cleanupOldSentForms()
       .then((count) => {
@@ -171,6 +182,7 @@ export default function App() {
       <PaperProvider theme={paperTheme}>
         <NavigationContainer
           key={isLoggedIn ? "logged-in" : "logged-out"}
+          linking={linking}
           theme={{
             ...navigationTheme,
             colors: {
@@ -202,6 +214,11 @@ export default function App() {
               name="FormScreen"
               component={FormScreen}
               options={{ title: "Form" }}
+            />
+            <RootStack.Screen
+              name="EmbeddedFormScreen"
+              component={EmbeddedFormScreen}
+              options={{ headerShown: false }}
             />
           </RootStack.Navigator>
           <Modal transparent visible={sessionExpired} animationType="fade">

--- a/navigation/types.ts
+++ b/navigation/types.ts
@@ -25,4 +25,9 @@ export type RootStackParamList = {
     draftId?: string;
     readOnly?: boolean;
   };
+  EmbeddedFormScreen: {
+    user?: string;
+    survey?: string;
+    readOnly?: boolean | string;
+  };
 };

--- a/screens/EmbeddedFormScreen.tsx
+++ b/screens/EmbeddedFormScreen.tsx
@@ -1,0 +1,74 @@
+import { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { useEffect, useState } from 'react';
+import { ActivityIndicator, StyleSheet, Text, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+
+import FormRenderer from '@/components/formRenderer';
+import type { FormSchema } from '@/components/formRenderer/fields/types';
+import { RootStackParamList } from '@/navigation/types';
+import { fetchEmbeddedForm } from '@/services/embeddedFormService';
+
+export type EmbeddedFormParams = {
+  user?: string;
+  survey?: string;
+  readOnly?: boolean | string;
+};
+
+type Props = NativeStackScreenProps<RootStackParamList, 'EmbeddedFormScreen'>;
+
+export default function EmbeddedFormScreen({ route }: Props) {
+  const { user, survey, readOnly } = (route.params || {}) as EmbeddedFormParams;
+  const [schema, setSchema] = useState<FormSchema | null>(null);
+  const [data, setData] = useState<Record<string, any> | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!user || !survey) {
+      setError('Missing parameters');
+      setLoading(false);
+      return;
+    }
+    fetchEmbeddedForm(user, survey)
+      .then((res) => {
+        setSchema(res.schema);
+        setData(res.data);
+      })
+      .catch((err) => {
+        setError(err instanceof Error ? err.message : String(err));
+      })
+      .finally(() => setLoading(false));
+  }, [user, survey]);
+
+  if (loading) {
+    return (
+      <SafeAreaView style={styles.center}>
+        <ActivityIndicator />
+      </SafeAreaView>
+    );
+  }
+
+  if (error || !schema) {
+    return (
+      <SafeAreaView style={styles.center}>
+        <Text>{error || 'Failed to load form.'}</Text>
+      </SafeAreaView>
+    );
+  }
+
+  const isReadOnly = readOnly === true || readOnly === 'true';
+
+  return (
+    <SafeAreaView style={{ flex: 1 }}>
+      <FormRenderer schema={schema} initialData={data ?? {}} readOnly={isReadOnly} />
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  center: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+});

--- a/services/embeddedFormService.ts
+++ b/services/embeddedFormService.ts
@@ -1,0 +1,26 @@
+import type { FormSchema } from '@/components/formRenderer/fields/types';
+import { getToken } from './authService';
+
+export type EmbeddedFormResponse = {
+  schema: FormSchema;
+  data: Record<string, any>;
+  formType?: string;
+  formName?: string;
+};
+
+const API_BASE = 'https://uat.onsite-lite.co.uk/api/Instance/GetEmbeddedForm';
+
+export async function fetchEmbeddedForm(
+  userGuid: string,
+  surveyGuid: string,
+): Promise<EmbeddedFormResponse> {
+  const token = await getToken();
+  const url = `${API_BASE}?user=${encodeURIComponent(userGuid)}&survey=${encodeURIComponent(surveyGuid)}`;
+  const res = await fetch(url, {
+    headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+  });
+  if (!res.ok) {
+    throw new Error(`HTTP ${res.status}`);
+  }
+  return (await res.json()) as EmbeddedFormResponse;
+}


### PR DESCRIPTION
## Summary
- support linking and create EmbeddedFormScreen
- fetch embedded form data via fetchEmbeddedForm service
- wire up navigation for new screen

## Testing
- `npx expo lint` *(fails: expo not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_687b41f76a7083288ddb15209116bdca