### PR TITLE
Add section rename and clone

### DIFF
--- a/components/formRenderer/hooks/useFormState.ts
+++ b/components/formRenderer/hooks/useFormState.ts
@@ -91,6 +91,19 @@ export function useFormState(schema: FormSchema, initialData?: Record<string, an
     });
     return ids;
   });
+  const [instanceNames, setInstanceNames] = useState<Record<string, string[]>>(() => {
+    const names: Record<string, string[]> = {};
+    schema.forEach((section) => {
+      if (section.repeatable) {
+        const length = ((initialData?.[section.key] as any[]) ?? []).length;
+        names[section.key] = Array.from(
+          { length },
+          (_, i) => `${section.label} ${i + 1}`,
+        );
+      }
+    });
+    return names;
+  });
   const [activeDateKey, setActiveDateKey] = useState<string | null>(null);
 
   const buildExpandedState = () => {
@@ -124,6 +137,19 @@ export function useFormState(schema: FormSchema, initialData?: Record<string, an
         });
         return ids;
       });
+      setInstanceNames(() => {
+        const names: Record<string, string[]> = {};
+        schema.forEach((section) => {
+          if (section.repeatable) {
+            const length = ((initialData?.[section.key] as any[]) ?? []).length;
+            names[section.key] = Array.from(
+              { length },
+              (_, i) => `${section.label} ${i + 1}`,
+            );
+          }
+        });
+        return names;
+      });
       setExpandedSections(buildExpandedState());
       setErroredSections({});
     }
@@ -147,6 +173,8 @@ export function useFormState(schema: FormSchema, initialData?: Record<string, an
     setFormErrors,
     instanceIds,
     setInstanceIds,
+    instanceNames,
+    setInstanceNames,
     activeDateKey,
     setActiveDateKey,
     expandedSections,

--- a/components/formRenderer/styles.ts
+++ b/components/formRenderer/styles.ts
@@ -87,5 +87,17 @@ export const styles = StyleSheet.create({
   },
   formTextInput: {
     padding: 0
+  },
+  modalOverlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.5)',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  modalContent: {
+    backgroundColor: 'white',
+    padding: 20,
+    width: '80%',
+    gap: 12,
   }
 });


### PR DESCRIPTION
## Summary
- support storing custom names for repeatable sections
- allow renaming and cloning of repeatable form sections
- style modal for rename popup

## Testing
- `npm run lint` *(fails: "lint" is not an expo command)*

------
https://chatgpt.com/codex/tasks/task_e_6884e779d5a48328822999a1712ceabf