### PR TITLE
Move repeatable section actions

### DIFF
--- a/components/formRenderer/FormRenderer.tsx
+++ b/components/formRenderer/FormRenderer.tsx
@@ -232,6 +232,19 @@ export const FormRenderer = forwardRef<FormRendererRef, FormRendererProps>(
                 }}
               >
                 <View style={styles.sectionContent}>
+                  <View style={styles.repeatableActions}>
+                    <Button
+                      title="Rename"
+                      onPress={() => {
+                        setRenameValue(
+                          instanceNames[section.key]?.[idx] ?? `${section.label} ${idx + 1}`,
+                        );
+                        setRenameInfo({ key: section.key, idx });
+                      }}
+                    />
+                    <Button title="Copy" onPress={() => cloneSection(section.key, idx)} />
+                    <Button title="Remove" onPress={() => removeSection(section.key, idx)} />
+                  </View>
                   {section.fields.map((f) => (
                     <FieldRenderer
                       key={`${section.key}-${idx}-${f.key}`}
@@ -249,12 +262,6 @@ export const FormRenderer = forwardRef<FormRendererRef, FormRendererProps>(
                       readOnly={readOnly}
                     />
                   ))}
-                  <Button title="Rename" onPress={() => {
-                    setRenameValue(instanceNames[section.key]?.[idx] ?? `${section.label} ${idx + 1}`);
-                    setRenameInfo({ key: section.key, idx });
-                  }} />
-                  <Button title="Copy" onPress={() => cloneSection(section.key, idx)} />
-                  <Button title="Remove" onPress={() => removeSection(section.key, idx)} />
                 </View>
               </Collapsible>
             ))}

--- a/components/formRenderer/styles.ts
+++ b/components/formRenderer/styles.ts
@@ -85,6 +85,12 @@ export const styles = StyleSheet.create({
     gap: 8,
     marginTop: 8,
   },
+  repeatableActions: {
+    flexDirection: 'row',
+    justifyContent: 'flex-end',
+    alignItems: 'center',
+    gap: 8,
+  },
   formTextInput: {
     padding: 0
   },


### PR DESCRIPTION
## Summary
- align repeatable section buttons horizontally
- show Rename/Copy/Remove actions at the top of repeatable sections

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6884e9f2dcd08328b58c3b49b10baef2