### PR TITLE
Add environment config for multiple builds

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -1,0 +1,1 @@
+EXPO_PUBLIC_API_BASE_URL=https://dev.onsite-lite.co.uk

--- a/.env.live
+++ b/.env.live
@@ -1,0 +1,1 @@
+EXPO_PUBLIC_API_BASE_URL=https://live.onsite-lite.co.uk

--- a/.env.qa
+++ b/.env.qa
@@ -1,0 +1,1 @@
+EXPO_PUBLIC_API_BASE_URL=https://qa.onsite-lite.co.uk

--- a/.env.staging
+++ b/.env.staging
@@ -1,0 +1,1 @@
+EXPO_PUBLIC_API_BASE_URL=https://staging.onsite-lite.co.uk

--- a/.env.uat
+++ b/.env.uat
@@ -1,0 +1,1 @@
+EXPO_PUBLIC_API_BASE_URL=https://uat.onsite-lite.co.uk

--- a/README.md
+++ b/README.md
@@ -16,6 +16,17 @@ This is an [Expo](https://expo.dev) project created with [`create-expo-app`](htt
    npx expo start
    ```
 
+### Choose an environment
+
+Environment specific API URLs are defined in `.env.*` files. Pass the desired
+file to Expo using the `--env-file` option:
+
+```bash
+npx expo start --env-file .env.dev
+```
+
+Valid environment files include `dev`, `qa`, `uat`, `staging` and `live`.
+
 In the output, you'll find options to open the app in a
 
 - [development build](https://docs.expo.dev/develop/development-builds/introduction/)

--- a/app.config.ts
+++ b/app.config.ts
@@ -1,0 +1,17 @@
+import 'dotenv/config';
+import type { ExpoConfig } from '@expo/config-types';
+
+const ENV = process.env.APP_ENV || 'dev';
+
+const DEFAULT_API_URL = 'https://uat.onsite-lite.co.uk';
+
+const API_URL = process.env.EXPO_PUBLIC_API_BASE_URL || DEFAULT_API_URL;
+
+export default ({ config }: { config: ExpoConfig }): ExpoConfig => ({
+  ...config,
+  extra: {
+    ...config.extra,
+    apiBaseUrl: API_URL,
+    appEnv: ENV,
+  },
+});

--- a/constants/api.ts
+++ b/constants/api.ts
@@ -1,0 +1,6 @@
+import Constants from 'expo-constants';
+
+export const API_BASE_URL: string =
+  (Constants.expoConfig?.extra?.apiBaseUrl as string | undefined) ||
+  (Constants.manifest?.extra as any)?.apiBaseUrl ||
+  'https://uat.onsite-lite.co.uk';

--- a/eas.json
+++ b/eas.json
@@ -13,6 +13,24 @@
     },
     "production": {
       "autoIncrement": true
+    },
+    "dev": {
+      "developmentClient": true,
+      "distribution": "internal",
+      "env": { "APP_ENV": "dev" }
+    },
+    "qa": {
+      "env": { "APP_ENV": "qa" }
+    },
+    "uat": {
+      "env": { "APP_ENV": "uat" }
+    },
+    "staging": {
+      "env": { "APP_ENV": "staging" }
+    },
+    "live": {
+      "autoIncrement": true,
+      "env": { "APP_ENV": "live" }
     }
   },
   "submit": {

--- a/screens/LoginScreen.tsx
+++ b/screens/LoginScreen.tsx
@@ -2,6 +2,7 @@ import { useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import Constants from 'expo-constants';
 import { useEffect, useState } from 'react';
+import { API_BASE_URL } from '@/constants/api';
 import {
   Alert,
   Image,
@@ -50,7 +51,7 @@ export default function LoginScreen({ onLogin }: Props) {
   const handleLogin = async () => {
     try {
       const response = await fetch(
-        'https://uat.onsite-lite.co.uk/api/Authentication/login',
+        `${API_BASE_URL}/api/Authentication/login`,
         {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },

--- a/services/embeddedFormService.ts
+++ b/services/embeddedFormService.ts
@@ -1,5 +1,6 @@
 import type { FormSchema } from '@/components/formRenderer/fields/types';
 import { getToken } from './authService';
+import { API_BASE_URL } from '@/constants/api';
 
 export type EmbeddedFormResponse = {
   schema: FormSchema;
@@ -8,7 +9,7 @@ export type EmbeddedFormResponse = {
   formName?: string;
 };
 
-const API_BASE = 'https://uat.onsite-lite.co.uk/api/Instance/GetEmbeddedForm';
+const API_BASE = `${API_BASE_URL}/api/Instance/GetEmbeddedForm`;
 
 export async function fetchEmbeddedForm(
   userGuid: string,

--- a/services/formTemplateService.ts
+++ b/services/formTemplateService.ts
@@ -8,7 +8,9 @@ export type FormTemplate = {
   schema: FormSchema;
 };
 
-const API_ENDPOINT = 'https://uat.onsite-lite.co.uk/api/FormTemplates';
+import { API_BASE_URL } from '@/constants/api';
+
+const API_ENDPOINT = `${API_BASE_URL}/api/FormTemplates`;
 const CACHE_KEY = 'cached_form_types';
 const TIMESTAMP_KEY = 'cached_form_types_timestamp';
 const CACHE_MS = 7 * 24 * 60 * 60 * 1000; // 7 days

--- a/services/outboxService.ts
+++ b/services/outboxService.ts
@@ -3,6 +3,7 @@ import * as FileSystem from 'expo-file-system';
 import jwtDecode from 'jwt-decode';
 import { getToken } from './authService';
 import type { DraftForm } from './draftService';
+import { API_BASE_URL } from '@/constants/api';
 
 export type OutboxForm =
   Omit<DraftForm, 'status'> & {
@@ -13,7 +14,7 @@ export type OutboxForm =
 
 const INDEX_KEY = 'outbox:index';
 const SENT_INDEX_KEY = 'sent:index';
-const SYNC_ENDPOINT = 'https://uat.onsite-lite.co.uk/api/Instance/SaveInstance';
+const SYNC_ENDPOINT = `${API_BASE_URL}/api/Instance/SaveInstance`;
 
 async function convertImagesToBase64(obj: any): Promise<any> {
   if (Array.isArray(obj)) {


### PR DESCRIPTION
## Summary
- configure base URL using Expo config in `app.config.ts`
- create environment-specific `.env.*` files
- expose API_BASE_URL constant
- update services and login screen to use configured base URL
- add build profiles in `eas.json`
- document environments in README

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6887c6a000808328acfdb138a3273471