### PR TITLE
feat: support separate form API base url

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -6,12 +6,15 @@ const ENV = process.env.APP_ENV || 'dev';
 const DEFAULT_API_URL = 'https://uat.onsite-lite.co.uk';
 
 const API_URL = process.env.EXPO_PUBLIC_API_BASE_URL || DEFAULT_API_URL;
+const FORM_API_URL =
+  process.env.EXPO_PUBLIC_FORM_API_BASE_URL || API_URL;
 
 export default ({ config }: { config: ExpoConfig }): ExpoConfig => ({
   ...config,
   extra: {
     ...config.extra,
     apiBaseUrl: API_URL,
+    formApiBaseUrl: FORM_API_URL,
     appEnv: ENV,
   },
 });

--- a/constants/api.ts
+++ b/constants/api.ts
@@ -4,3 +4,8 @@ export const API_BASE_URL: string =
   (Constants.expoConfig?.extra?.apiBaseUrl as string | undefined) ||
   (Constants.manifest?.extra as any)?.apiBaseUrl ||
   'https://uat.onsite-lite.co.uk';
+
+export const FORM_API_BASE_URL: string =
+  (Constants.expoConfig?.extra?.formApiBaseUrl as string | undefined) ||
+  (Constants.manifest?.extra as any)?.formApiBaseUrl ||
+  API_BASE_URL;

--- a/services/embeddedFormService.ts
+++ b/services/embeddedFormService.ts
@@ -1,6 +1,6 @@
 import type { FormSchema } from '@/components/formRenderer/fields/types';
 import { getToken } from './authService';
-import { API_BASE_URL } from '@/constants/api';
+import { FORM_API_BASE_URL } from '@/constants/api';
 
 export type EmbeddedFormResponse = {
   schema: FormSchema;
@@ -9,7 +9,7 @@ export type EmbeddedFormResponse = {
   formName?: string;
 };
 
-const API_BASE = `${API_BASE_URL}/api/Instance/GetEmbeddedForm`;
+const API_BASE = `${FORM_API_BASE_URL}/api/Instance/GetEmbeddedForm`;
 
 export async function fetchEmbeddedForm(
   userGuid: string,

--- a/services/formTemplateService.ts
+++ b/services/formTemplateService.ts
@@ -8,9 +8,8 @@ export type FormTemplate = {
   schema: FormSchema;
 };
 
-import { API_BASE_URL } from '@/constants/api';
-
-const API_ENDPOINT = `${API_BASE_URL}/api/FormTemplates`;
+import { FORM_API_BASE_URL } from '@/constants/api';
+const API_ENDPOINT = `${FORM_API_BASE_URL}/api/FormTemplates`;
 const CACHE_KEY = 'cached_form_types';
 const TIMESTAMP_KEY = 'cached_form_types_timestamp';
 const CACHE_MS = 7 * 24 * 60 * 60 * 1000; // 7 days


### PR DESCRIPTION
## Summary
- allow forms to use their own base API via new configuration
- update form template and embedded form services to fetch from the form API

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npx tsc --noEmit` *(fails: Could not find a declaration file for module 'uuid')*

------
https://chatgpt.com/codex/tasks/task_e_688dd465527c832887a586570922172a