### PR TITLE
feat: support nested form sections

### DIFF
--- a/components/formRenderer/fields/types.ts
+++ b/components/formRenderer/fields/types.ts
@@ -60,12 +60,22 @@ export type FormField =
       options: string[] | { label: string; value: string }[];
       required?: boolean;
       visibleWhen?: VisibleWhen;
+    }
+  | {
+      type: 'section';
+      key: string;
+      label: string;
+      repeatable?: boolean;
+      useModal?: boolean;
+      fields: FormField[];
+      visibleWhen?: VisibleWhen;
     };
 
 export type FormSection = {
   key: string;
   label: string;
   repeatable?: boolean;
+  useModal?: boolean;
   fields: FormField[];
 };
 

--- a/components/formRenderer/hooks/useFormState.ts
+++ b/components/formRenderer/hooks/useFormState.ts
@@ -1,55 +1,71 @@
 import { useEffect, useState } from 'react';
 import { v4 as uuidv4 } from 'uuid';
-import { FormSchema, FormSection } from '../fields/types';
-import { setNestedValue } from '../utils/formUtils';
+import { FormSchema, FormSection, FormField } from '../fields/types';
+import { getNestedValue, setNestedValue } from '../utils/formUtils';
 
 export function useFormState(schema: FormSchema, initialData?: Record<string, any>) {
-  function createEmptySection(section: FormSection) {
+  function createEmptySection(section: FormSection): Record<string, any> {
     const obj: Record<string, any> = {};
     section.fields.forEach((f) => {
-      switch (f.type) {
-        case 'photo':
-          obj[f.key] = [];
-          break;
-        case 'signature':
-          obj[f.key] = '';
-          break;
-        case 'boolean':
-          obj[f.key] = false;
-          break;
-        case 'number':
-        case 'decimal':
-        case 'currency':
-          obj[f.key] = undefined;
-          break;
-        case 'multiselect':
-          obj[f.key] = [];
-          break;
-        case 'time':
-        case 'datetime':
-        case 'barcode':
-        case 'imageSelect':
-          obj[f.key] = '';
-          break;
-        default:
-          obj[f.key] = '';
-          break;
+      if (f.type === 'section') {
+        obj[f.key] = f.repeatable ? [] : createEmptySection(f);
+      } else {
+        switch (f.type) {
+          case 'photo':
+            obj[f.key] = [];
+            break;
+          case 'signature':
+            obj[f.key] = '';
+            break;
+          case 'boolean':
+            obj[f.key] = false;
+            break;
+          case 'number':
+          case 'decimal':
+          case 'currency':
+            obj[f.key] = undefined;
+            break;
+          case 'multiselect':
+            obj[f.key] = [];
+            break;
+          case 'time':
+          case 'datetime':
+          case 'barcode':
+          case 'imageSelect':
+            obj[f.key] = '';
+            break;
+          default:
+            obj[f.key] = '';
+            break;
+        }
       }
     });
     return obj;
   }
 
-  function normalizeSectionData(section: FormSection, data: any) {
-    const result: Record<string, any> = { ...data };
+  function buildSection(section: FormSection, data: any): Record<string, any> {
+    const base = createEmptySection(section);
+    const result: Record<string, any> = { ...base };
     section.fields.forEach((f) => {
-      if (f.type === 'photo') {
-        const val = result[f.key];
+      if (f.type === 'section') {
+        if (f.repeatable) {
+          const arr = (data?.[f.key] as any[]) ?? [];
+          result[f.key] = arr.map((entry) => buildSection(f, entry));
+        } else {
+          result[f.key] = buildSection(f, data?.[f.key] ?? {});
+        }
+      } else if (f.type === 'photo') {
+        const val = data?.[f.key];
         if (val === undefined || val === null) {
           result[f.key] = [];
         } else if (Array.isArray(val)) {
           result[f.key] = val;
         } else {
           result[f.key] = [val];
+        }
+      } else {
+        if (data && Object.prototype.hasOwnProperty.call(data, f.key)) {
+          result[f.key] = data[f.key];
         }
       }
     });
@@ -60,20 +76,10 @@ export function useFormState(schema: FormSchema, initialData?: Record<string, an
     const state: Record<string, any> = {};
     schema.forEach((section) => {
       if (section.repeatable) {
-        const arr: Record<string, any>[] = [];
         const initialArr = (initialData?.[section.key] as any[]) ?? [];
-        initialArr.forEach((entry) => {
-          arr.push({
-            ...createEmptySection(section),
-            ...normalizeSectionData(section, entry),
-          });
-        });
-        state[section.key] = arr;
+        state[section.key] = initialArr.map((entry) => buildSection(section, entry));
       } else {
-        state[section.key] = {
-          ...createEmptySection(section),
-          ...normalizeSectionData(section, initialData?.[section.key] ?? {}),
-        };
+        state[section.key] = buildSection(section, initialData?.[section.key] ?? {});
       }
     });
     return state;
@@ -81,47 +87,82 @@ export function useFormState(schema: FormSchema, initialData?: Record<string, an
 
   const [formState, setFormState] = useState<Record<string, any>>(buildInitialState);
   const [formErrors, setFormErrors] = useState<Record<string, string>>({});
-  const [instanceIds, setInstanceIds] = useState<Record<string, string[]>>(() => {
-    const ids: Record<string, string[]> = {};
-    schema.forEach((section) => {
+  function buildInstanceMaps(
+    sections: FormSchema,
+    basePath: (string | number)[],
+    data: Record<string, any>,
+    ids: Record<string, string[]>,
+    names: Record<string, string[]>,
+  ) {
+    sections.forEach((section) => {
+      const currentPath = [...basePath, section.key];
+      const pathKey = currentPath.join('.');
       if (section.repeatable) {
-        const length = ((initialData?.[section.key] as any[]) ?? []).length;
-        ids[section.key] = Array.from({ length }, () => uuidv4());
+        const arr: any[] = getNestedValue(data, currentPath) ?? [];
+        ids[pathKey] = Array.from({ length: arr.length }, () => uuidv4());
+        names[pathKey] = Array.from({ length: arr.length }, (_, i) => `${section.label} ${i + 1}`);
+        arr.forEach((row, idx) => {
+          buildInstanceMaps(section.fields.filter((f): f is FormSection => f.type === 'section'), [...currentPath, idx], row, ids, names);
+        });
+      } else {
+        const row: Record<string, any> = getNestedValue(data, currentPath) ?? {};
+        buildInstanceMaps(section.fields.filter((f): f is FormSection => f.type === 'section'), currentPath, row, ids, names);
       }
     });
+  }
+
+  const [instanceIds, setInstanceIds] = useState<Record<string, string[]>>(() => {
+    const ids: Record<string, string[]> = {};
+    buildInstanceMaps(schema, [], buildInitialState(), ids, {});
     return ids;
   });
   const [instanceNames, setInstanceNames] = useState<Record<string, string[]>>(() => {
     const names: Record<string, string[]> = {};
-    schema.forEach((section) => {
-      if (section.repeatable) {
-        const length = ((initialData?.[section.key] as any[]) ?? []).length;
-        names[section.key] = Array.from(
-          { length },
-          (_, i) => `${section.label} ${i + 1}`,
-        );
-      }
-    });
+    buildInstanceMaps(schema, [], buildInitialState(), {}, names);
     return names;
   });
   const [activeDateKey, setActiveDateKey] = useState<string | null>(null);
 
-  const buildExpandedState = () => {
+  const buildExpandedState = (
+    sections: FormSchema,
+    basePath: (string | number)[],
+    data: Record<string, any>,
+  ): Record<string, boolean> => {
     const expanded: Record<string, boolean> = {};
-    schema.forEach((section) => {
+    sections.forEach((section) => {
+      const currentPath = [...basePath, section.key];
+      const pathKey = currentPath.join('.');
       if (section.repeatable) {
-        const length = ((initialData?.[section.key] as any[]) ?? []).length;
-        for (let i = 0; i < length; i++) {
-          expanded[`${section.key}.${i}`] = false;
+        const arr: any[] = getNestedValue(data, currentPath) ?? [];
+        for (let i = 0; i < arr.length; i++) {
+          expanded[`${pathKey}.${i}`] = false;
+          Object.assign(
+            expanded,
+            buildExpandedState(
+              section.fields.filter((f): f is FormSection => f.type === 'section'),
+              [...currentPath, i],
+              getNestedValue(data, [...currentPath, i]) ?? {},
+            ),
+          );
         }
       } else {
-        expanded[section.key] = false;
+        expanded[pathKey] = false;
+        Object.assign(
+          expanded,
+          buildExpandedState(
+            section.fields.filter((f): f is FormSection => f.type === 'section'),
+            currentPath,
+            getNestedValue(data, currentPath) ?? {},
+          ),
+        );
       }
     });
     return expanded;
   };
 
-  const [expandedSections, setExpandedSections] = useState<Record<string, boolean>>(buildExpandedState);
+  const [expandedSections, setExpandedSections] = useState<Record<string, boolean>>(() =>
+    buildExpandedState(schema, [], buildInitialState()),
+  );
   const [erroredSections, setErroredSections] = useState<Record<string, boolean>>({});
 
   useEffect(() => {
@@ -129,28 +170,15 @@ export function useFormState(schema: FormSchema, initialData?: Record<string, an
       setFormState(buildInitialState());
       setInstanceIds(() => {
         const ids: Record<string, string[]> = {};
-        schema.forEach((section) => {
-          if (section.repeatable) {
-            const length = ((initialData?.[section.key] as any[]) ?? []).length;
-            ids[section.key] = Array.from({ length }, () => uuidv4());
-          }
-        });
+        buildInstanceMaps(schema, [], buildInitialState(), ids, {});
         return ids;
       });
       setInstanceNames(() => {
         const names: Record<string, string[]> = {};
-        schema.forEach((section) => {
-          if (section.repeatable) {
-            const length = ((initialData?.[section.key] as any[]) ?? []).length;
-            names[section.key] = Array.from(
-              { length },
-              (_, i) => `${section.label} ${i + 1}`,
-            );
-          }
-        });
+        buildInstanceMaps(schema, [], buildInitialState(), {}, names);
         return names;
       });
-      setExpandedSections(buildExpandedState());
+      setExpandedSections(buildExpandedState(schema, [], buildInitialState()));
       setErroredSections({});
     }
   }, [initialData, schema]);


### PR DESCRIPTION
## Summary
- expand form field types to include nested sections and modal flag
- enhance form utilities to recursively traverse nested sections
- extend form state hooks to initialize and manage nested sections

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_688e4d7d10708328a739742a5b4adc38