### PR TITLE
feat: add web form builder

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -30,6 +30,7 @@ import SentScreen from "@/screens/SentScreen";
 import SettingsScreen from "@/screens/SettingsScreen";
 import { cleanupOldSentForms } from "@/services/sentService";
 import EmbeddedFormScreen from "@/screens/EmbeddedFormScreen";
+import FormBuilderScreen from "@/screens/FormBuilderScreen";
 
 const RootStack = createNativeStackNavigator<RootStackParamList>();
 const DraftsStack = createNativeStackNavigator<DraftsStackParamList>();
@@ -153,6 +154,7 @@ export default function App() {
     config: {
       screens: {
         EmbeddedFormScreen: 'embedded-form',
+        FormBuilderScreen: 'form-builder',
       },
     },
   };
@@ -219,6 +221,11 @@ export default function App() {
               name="EmbeddedFormScreen"
               component={EmbeddedFormScreen}
               options={{ headerShown: false }}
+            />
+            <RootStack.Screen
+              name="FormBuilderScreen"
+              component={FormBuilderScreen}
+              options={{ title: "Form Builder" }}
             />
           </RootStack.Navigator>
           <Modal transparent visible={sessionExpired} animationType="fade">

--- a/navigation/types.ts
+++ b/navigation/types.ts
@@ -30,4 +30,5 @@ export type RootStackParamList = {
     survey?: string;
     readOnly?: boolean | string;
   };
+  FormBuilderScreen: undefined;
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "onsitepro",
       "version": "1.0.0",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@expo/vector-icons": "^14.1.0",
         "@react-native-async-storage/async-storage": "^2.2.0",
         "@react-native-community/datetimepicker": "^8.4.2",
@@ -37,6 +40,7 @@
         "js-sha256": "^0.11.1",
         "jwt-decode": "^3.1.2",
         "react": "19.0.0",
+        "react-device-detect": "^2.2.3",
         "react-dom": "19.0.0",
         "react-native": "0.79.5",
         "react-native-dropdown-picker": "^5.4.3",
@@ -50,6 +54,7 @@
         "react-native-vector-icons": "^10.2.0",
         "react-native-web": "~0.20.0",
         "react-native-webview": "13.13.5",
+        "react18-json-view": "^0.2.9",
         "uuid": "^9.0.0"
       },
       "devDependencies": {
@@ -1568,6 +1573,59 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@egjs/hammerjs": {
@@ -5162,6 +5220,15 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "license": "MIT"
+    },
+    "node_modules/copy-to-clipboard": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.3.tgz",
+      "integrity": "sha512-2KV8NhB5JqC3ky0r9PMCAZKbUHSwtEo4CwCs0KXgruG43gX5PMqDEBbVU4OUzw2MuAWUfsuFmWvEKG5QRfSnJA==",
+      "license": "MIT",
+      "dependencies": {
+        "toggle-selection": "^1.0.6"
+      }
     },
     "node_modules/core-js-compat": {
       "version": "3.44.0",
@@ -10259,6 +10326,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-device-detect": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/react-device-detect/-/react-device-detect-2.2.3.tgz",
+      "integrity": "sha512-buYY3qrCnQVlIFHrC5UcUoAj7iANs/+srdkwsnNjI7anr3Tt7UY6MqNxtMLlr0tMBied0O49UZVK8XKs3ZIiPw==",
+      "license": "MIT",
+      "dependencies": {
+        "ua-parser-js": "^1.0.33"
+      },
+      "peerDependencies": {
+        "react": ">= 0.14.0",
+        "react-dom": ">= 0.14.0"
+      }
+    },
     "node_modules/react-devtools-core": {
       "version": "6.1.5",
       "resolved": "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-6.1.5.tgz",
@@ -10769,6 +10849,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react18-json-view": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/react18-json-view/-/react18-json-view-0.2.9.tgz",
+      "integrity": "sha512-z3JQgCwZRKbmWh54U94loCU6vE0ZoDBK7C8ZpcMYQB8jYMi+mR/fcgMI9jKgATeF0I6+OAF025PD+UKkXIqueQ==",
+      "license": "MIT",
+      "dependencies": {
+        "copy-to-clipboard": "^3.3.3"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -12286,6 +12378,12 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/toggle-selection": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
+      "integrity": "sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ==",
+      "license": "MIT"
+    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -12350,9 +12448,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD",
-      "optional": true
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
     "lint": "expo lint"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@expo/vector-icons": "^14.1.0",
     "@react-native-async-storage/async-storage": "^2.2.0",
     "@react-native-community/datetimepicker": "^8.4.2",
@@ -40,6 +43,7 @@
     "js-sha256": "^0.11.1",
     "jwt-decode": "^3.1.2",
     "react": "19.0.0",
+    "react-device-detect": "^2.2.3",
     "react-dom": "19.0.0",
     "react-native": "0.79.5",
     "react-native-dropdown-picker": "^5.4.3",
@@ -53,6 +57,7 @@
     "react-native-vector-icons": "^10.2.0",
     "react-native-web": "~0.20.0",
     "react-native-webview": "13.13.5",
+    "react18-json-view": "^0.2.9",
     "uuid": "^9.0.0"
   },
   "devDependencies": {

--- a/screens/FormBuilderScreen.tsx
+++ b/screens/FormBuilderScreen.tsx
@@ -1,0 +1,18 @@
+import { View, Text, StyleSheet } from 'react-native';
+
+export default function FormBuilderScreen() {
+  return (
+    <View style={styles.container}>
+      <Text>Form builder is only available on desktop web.</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: 16,
+  },
+});

--- a/screens/FormBuilderScreen.web.tsx
+++ b/screens/FormBuilderScreen.web.tsx
@@ -1,0 +1,228 @@
+import React, { useState } from 'react';
+import { View, Text, StyleSheet, TextInput, ScrollView } from 'react-native';
+import { Checkbox } from 'react-native-paper';
+import {
+  DndContext,
+  DragEndEvent,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  useDraggable,
+  useDroppable,
+} from '@dnd-kit/core';
+import {
+  SortableContext,
+  useSortable,
+  arrayMove,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
+import { v4 as uuidv4 } from 'uuid';
+import JsonView from 'react18-json-view';
+import 'react18-json-view/src/style.css';
+import { isDesktop } from 'react-device-detect';
+
+type BuilderField = {
+  id: string;
+  type: string;
+  label: string;
+  required: boolean;
+};
+
+const palette = [
+  { id: 'text', type: 'text', label: 'Text' },
+  { id: 'number', type: 'number', label: 'Number' },
+  { id: 'date', type: 'date', label: 'Date' },
+];
+
+function PaletteItem({ item }: { item: { id: string; type: string; label: string } }) {
+  const { attributes, listeners, setNodeRef, transform, isDragging } = useDraggable({
+    id: item.id,
+    data: { from: 'palette', type: item.type },
+  });
+  const style = {
+    transform: transform
+      ? [{ translateX: transform.x }, { translateY: transform.y }]
+      : undefined,
+    opacity: isDragging ? 0.5 : 1,
+  } as const;
+  return (
+    <View ref={setNodeRef} {...attributes} {...listeners} style={[styles.paletteItem, style]}>
+      <Text>{item.label}</Text>
+    </View>
+  );
+}
+
+function SortableField({
+  field,
+  update,
+}: {
+  field: BuilderField;
+  update: (id: string, patch: Partial<BuilderField>) => void;
+}) {
+  const { attributes, listeners, setNodeRef, transform, isDragging } = useSortable({
+    id: field.id,
+    data: { from: 'form' },
+  });
+  const style = {
+    transform: transform
+      ? [{ translateX: transform.x }, { translateY: transform.y }]
+      : undefined,
+    zIndex: isDragging ? 100 : 0,
+  } as const;
+  return (
+    <View ref={setNodeRef} style={[styles.formItem, style]}> 
+      <View {...attributes} {...listeners}>
+        <Text style={styles.formItemType}>{field.type}</Text>
+      </View>
+      <TextInput
+        style={styles.input}
+        value={field.label}
+        onChangeText={(text) => update(field.id, { label: text })}
+        placeholder="Label"
+      />
+      <View style={styles.checkboxRow}>
+        <Checkbox
+          status={field.required ? 'checked' : 'unchecked'}
+          onPress={() => update(field.id, { required: !field.required })}
+        />
+        <Text>Required</Text>
+      </View>
+    </View>
+  );
+}
+
+export default function FormBuilderScreen() {
+  const [fields, setFields] = useState<BuilderField[]>([]);
+  const sensors = useSensors(useSensor(PointerSensor));
+  const { setNodeRef } = useDroppable({ id: 'form' });
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (!over) return;
+    if (active.data.current?.from === 'palette') {
+      const template = palette.find((p) => p.id === active.id);
+      if (template) {
+        const newField: BuilderField = {
+          id: uuidv4(),
+          type: template.type,
+          label: template.label,
+          required: false,
+        };
+        setFields((prev) => {
+          const newFields = [...prev];
+          if (over.id === 'form') {
+            newFields.push(newField);
+          } else {
+            const index = prev.findIndex((f) => f.id === over.id);
+            if (index >= 0) newFields.splice(index, 0, newField);
+            else newFields.push(newField);
+          }
+          return newFields;
+        });
+      }
+    } else if (active.data.current?.from === 'form') {
+      if (over.id === active.id) return;
+      setFields((prev) => {
+        const oldIndex = prev.findIndex((f) => f.id === active.id);
+        const newIndex =
+          over.id === 'form' ? prev.length - 1 : prev.findIndex((f) => f.id === over.id);
+        if (oldIndex === -1 || newIndex === -1) return prev;
+        return arrayMove(prev, oldIndex, newIndex);
+      });
+    }
+  };
+
+  const updateField = (id: string, patch: Partial<BuilderField>) => {
+    setFields((prev) => prev.map((f) => (f.id === id ? { ...f, ...patch } : f)));
+  };
+
+  if (!isDesktop) {
+    return (
+      <View style={styles.center}>
+        <Text>Form builder is only available on desktop.</Text>
+      </View>
+    );
+  }
+
+  const schema = fields.map(({ id, label, type, required }) => ({
+    id,
+    label,
+    type,
+    required,
+  }));
+
+  return (
+    <ScrollView contentContainerStyle={styles.container}>
+      <DndContext sensors={sensors} onDragEnd={handleDragEnd}>
+        <View style={styles.builder}>
+          <View style={styles.palette}>
+            <Text style={styles.heading}>Fields</Text>
+            {palette.map((p) => (
+              <PaletteItem key={p.id} item={p} />
+            ))}
+          </View>
+          <View style={styles.form} ref={setNodeRef}>
+            <Text style={styles.heading}>Form Layout</Text>
+            <SortableContext items={fields.map((f) => f.id)} strategy={verticalListSortingStrategy}>
+              {fields.map((field) => (
+                <SortableField key={field.id} field={field} update={updateField} />
+              ))}
+            </SortableContext>
+          </View>
+        </View>
+      </DndContext>
+      <View style={styles.preview}>
+        <Text style={styles.heading}>JSON Preview</Text>
+        <JsonView src={schema} editable={false} enableClipboard={false} />
+      </View>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { padding: 16, gap: 16 },
+  builder: { flexDirection: 'row', gap: 16 },
+  palette: {
+    width: 200,
+    padding: 8,
+    borderWidth: 1,
+    borderColor: '#ccc',
+    borderRadius: 4,
+    gap: 8,
+  },
+  paletteItem: {
+    padding: 8,
+    borderWidth: 1,
+    borderColor: '#ccc',
+    borderRadius: 4,
+    backgroundColor: '#fff',
+  },
+  form: {
+    flex: 1,
+    padding: 8,
+    borderWidth: 1,
+    borderColor: '#ccc',
+    borderRadius: 4,
+    minHeight: 200,
+    gap: 8,
+  },
+  formItem: {
+    padding: 8,
+    borderWidth: 1,
+    borderColor: '#ddd',
+    borderRadius: 4,
+    backgroundColor: '#fafafa',
+    gap: 8,
+  },
+  formItemType: { fontWeight: 'bold', marginBottom: 4 },
+  input: {
+    borderWidth: 1,
+    borderColor: '#ccc',
+    padding: 4,
+    borderRadius: 4,
+  },
+  checkboxRow: { flexDirection: 'row', alignItems: 'center' },
+  heading: { fontWeight: 'bold', marginBottom: 8 },
+  preview: { marginTop: 16 },
+  center: { flex: 1, justifyContent: 'center', alignItems: 'center', padding: 16 },
+});


### PR DESCRIPTION
## Summary
- add desktop-only form builder screen with drag-and-drop and JSON preview
- wire up /form-builder route and navigation
- install dnd-kit, react18-json-view, and react-device-detect dependencies

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688e7fc6ec60832889dfc7eade58cf92