### PR TITLE
feat: add offline scaffolding

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -16,6 +16,7 @@ import * as SecureStore from "./services/secureStoreWrapper";
 import { darkTheme, lightTheme } from "@/constants/theme";
 import { FormCountsProvider, useFormCounts } from "@/context/FormCountsContext";
 import { useColorScheme } from "@/hooks/useColorScheme";
+import { useOfflineSync } from "@/hooks/useOfflineSync";
 import type {
   DraftsStackParamList,
   RootStackParamList,
@@ -109,6 +110,7 @@ export default function App() {
   const [isLoggedIn, setIsLoggedIn] = useState<boolean | null>(null);
   const [sessionExpired, setSessionExpired] = useState(false);
   const wasOffline = useRef(false);
+  useOfflineSync();
 
   useEffect(() => {
     async function loadStatus() {

--- a/__tests__/screens/DraftsScreen.test.tsx
+++ b/__tests__/screens/DraftsScreen.test.tsx
@@ -10,6 +10,10 @@ jest.mock('@/services/draftService', () => ({
   getDraftById: jest.fn(),
 }));
 
+jest.mock('@/hooks/useNetworkStatus', () => ({
+  useNetworkStatus: () => true,
+}));
+
 jest.mock('@/hooks/useAvailableForms', () => ({
   useAvailableForms: () => [
     { key: 'TEST', label: 'Test Form', icon: 'file-plus', formType: 'TEST', version: 1 },

--- a/hooks/useOfflineSync.ts
+++ b/hooks/useOfflineSync.ts
@@ -1,0 +1,12 @@
+import { useEffect } from 'react';
+import { useNetworkStatus } from './useNetworkStatus';
+import { syncOnce } from '@/src/offline/syncEngine';
+
+export function useOfflineSync() {
+  const isOnline = useNetworkStatus();
+  useEffect(() => {
+    if (isOnline) {
+      syncOnce().catch(() => {});
+    }
+  }, [isOnline]);
+}

--- a/screens/DraftsScreen.tsx
+++ b/screens/DraftsScreen.tsx
@@ -1,4 +1,3 @@
-import { createInstance } from "@/api/formsApi";
 import { useAvailableForms } from "@/hooks/useAvailableForms";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { useFocusEffect, useNavigation } from "@react-navigation/native";
@@ -20,6 +19,8 @@ import {
 } from "@/services/draftService";
 import { deleteLocalPhoto } from "@/services/photoService";
 import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
+import { createInstanceSmart } from "@/src/offline/instanceSmart";
+import { useNetworkStatus } from "@/hooks/useNetworkStatus";
 
 export default function DraftsScreen() {
   const navigation =
@@ -31,6 +32,7 @@ export default function DraftsScreen() {
   const [screenFocused, setScreenFocused] = useState(false);
   const forms = useAvailableForms();
   const theme = useTheme();
+  const isOnline = useNetworkStatus();
 
   const loadDrafts = useCallback(async () => {
     const data = await getAllDrafts();
@@ -182,8 +184,13 @@ export default function DraftsScreen() {
                 onPress: async () => {
                   setFabOpen(false);
                   try {
-                    const created = await createInstance(f.formType, f.version);
-                    navigation.navigate("FormInstance", { id: created.formInstanceId });
+                    const created = await createInstanceSmart(
+                      f.formType,
+                      f.version,
+                      {},
+                      isOnline,
+                    );
+                    navigation.navigate("FormInstance", { id: created.id });
                   } catch {
                     Alert.alert("Error", "Failed to create form instance");
                   }

--- a/src/offline/getInstanceSmart.ts
+++ b/src/offline/getInstanceSmart.ts
@@ -1,0 +1,45 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { getInstance } from '@/api/formsApi';
+import { K } from './keys';
+import type { LocalInstanceMeta } from './types';
+
+export async function resolveToServerId(id: string | number): Promise<string | number> {
+  if (typeof id === 'string' && id.startsWith('tmp_')) {
+    const mapped = await AsyncStorage.getItem(K.IdMap(id));
+    if (mapped) return Number(mapped);
+  }
+  return id;
+}
+
+export async function getInstanceSmart(id: string | number): Promise<(LocalInstanceMeta & { data: any }) | null> {
+  const resolved = await resolveToServerId(id);
+  if (typeof resolved === 'number' || (typeof resolved === 'string' && !resolved.startsWith('tmp_'))) {
+    try {
+      const dto = await getInstance(Number(resolved));
+      const meta: LocalInstanceMeta = {
+        id: String(resolved),
+        formType: (dto as any).formType || '',
+        formVersion: (dto as any).formVersion ?? null,
+        formDefinitionId: dto.formDefinitionId ?? null,
+        currentState: dto.currentState,
+        version: dto.version,
+        etag: dto.etag,
+        isLocal: false,
+        createdAt: new Date().toISOString(),
+      };
+      await AsyncStorage.setItem(K.InstanceMeta(resolved), JSON.stringify(meta));
+      await AsyncStorage.setItem(K.InstanceData(resolved), JSON.stringify(dto.data || {}));
+      return { ...meta, data: dto.data || {} };
+    } catch {
+      const metaRaw = await AsyncStorage.getItem(K.InstanceMeta(resolved));
+      const dataRaw = await AsyncStorage.getItem(K.InstanceData(resolved));
+      if (!metaRaw) return null;
+      return { ...(JSON.parse(metaRaw) as LocalInstanceMeta), data: dataRaw ? JSON.parse(dataRaw) : {} };
+    }
+  }
+
+  const metaRaw = await AsyncStorage.getItem(K.InstanceMeta(resolved));
+  const dataRaw = await AsyncStorage.getItem(K.InstanceData(resolved));
+  if (!metaRaw) return null;
+  return { ...(JSON.parse(metaRaw) as LocalInstanceMeta), data: dataRaw ? JSON.parse(dataRaw) : {} };
+}

--- a/src/offline/instanceSmart.ts
+++ b/src/offline/instanceSmart.ts
@@ -1,0 +1,93 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { createInstance } from '@/api/formsApi';
+import { K } from './keys';
+import { getFormTemplatesCached } from './templatesCache';
+import type { LocalInstanceMeta, CreateJob } from './types';
+
+function uuidv4(): string {
+  if (typeof globalThis.crypto?.randomUUID === 'function') {
+    return globalThis.crypto.randomUUID();
+  }
+  // fallback
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
+    const r = (Math.random() * 16) | 0;
+    const v = c === 'x' ? r : (r & 0x3) | 0x8;
+    return v.toString(16);
+  });
+}
+
+export async function createInstanceSmart(
+  formType: string,
+  formVersion?: number | null,
+  initialData: any = {},
+  isOnline: boolean = true,
+): Promise<LocalInstanceMeta> {
+  const idempotencyKey = uuidv4();
+
+  if (isOnline) {
+    const created = await createInstance(
+      formType,
+      formVersion ?? undefined,
+      initialData,
+      idempotencyKey,
+    );
+    const meta: LocalInstanceMeta = {
+      id: String(created.formInstanceId),
+      formType,
+      formVersion: (created as any).formVersion ?? formVersion ?? null,
+      formDefinitionId: created.formDefinitionId ?? null,
+      currentState: created.currentState,
+      version: created.version,
+      etag: created.etag,
+      isLocal: false,
+      createdAt: new Date().toISOString(),
+    };
+    await AsyncStorage.setItem(K.InstanceMeta(meta.id), JSON.stringify(meta));
+    await AsyncStorage.setItem(K.InstanceData(meta.id), JSON.stringify(created.data || {}));
+    return meta;
+  }
+
+  const tmpId = `tmp_${uuidv4()}`;
+  let currentState = 'draft';
+  try {
+    const defs = await getFormTemplatesCached(false);
+    const def = defs.find(
+      (d: any) =>
+        d.formType === formType &&
+        (formVersion == null || d.version === formVersion),
+    );
+    const wf = def?.workflow || {};
+    currentState =
+      wf.initial || wf.initialState || wf.start || currentState;
+  } catch {}
+
+  const meta: LocalInstanceMeta = {
+    id: tmpId,
+    formType,
+    formVersion: formVersion ?? null,
+    formDefinitionId: null,
+    currentState,
+    version: 0,
+    etag: '',
+    isLocal: true,
+    createdAt: new Date().toISOString(),
+  };
+
+  await AsyncStorage.setItem(K.InstanceMeta(tmpId), JSON.stringify(meta));
+  await AsyncStorage.setItem(K.InstanceData(tmpId), JSON.stringify(initialData || {}));
+
+  const job: CreateJob = {
+    tmpId,
+    formType,
+    formVersion: formVersion ?? null,
+    initialData,
+    idempotencyKey,
+  };
+  const raw = await AsyncStorage.getItem(K.CreateQueue);
+  const queue = raw ? JSON.parse(raw) : [];
+  queue.push(job);
+  await AsyncStorage.setItem(K.CreateQueue, JSON.stringify(queue));
+  await AsyncStorage.setItem(K.PatchQueue(tmpId), JSON.stringify([]));
+
+  return meta;
+}

--- a/src/offline/keys.ts
+++ b/src/offline/keys.ts
@@ -1,0 +1,7 @@
+export const K = {
+  CreateQueue: 'queue:create',
+  IdMap: (tmpId: string) => `map:temp:${tmpId}`,
+  InstanceMeta: (id: string|number) => `instance:meta:${id}`,
+  InstanceData: (id: string|number) => `instance:data:${id}`,
+  PatchQueue: (id: string|number) => `queue:form:${id}`,
+};

--- a/src/offline/syncEngine.ts
+++ b/src/offline/syncEngine.ts
@@ -1,0 +1,101 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { createInstance, saveSection, getInstance } from '@/api/formsApi';
+import { K } from './keys';
+import type { CreateJob, LocalInstanceMeta } from './types';
+
+async function drainPatchQueue(id: number, meta: LocalInstanceMeta) {
+  const pqKey = K.PatchQueue(id);
+  let raw = await AsyncStorage.getItem(pqKey);
+  let queue = raw ? JSON.parse(raw) : [];
+  while (queue.length) {
+    const item = queue[0];
+    try {
+      const updated = await saveSection({
+        id,
+        sectionKey: item.sectionKey,
+        patch: item.patch,
+        etag: meta.etag,
+        idempotencyKey: item.idempotencyKey,
+      });
+      meta.etag = updated.etag;
+      meta.version = updated.version;
+      meta.currentState = (updated as any).state ?? meta.currentState;
+      await AsyncStorage.setItem(K.InstanceMeta(id), JSON.stringify(meta));
+      await AsyncStorage.setItem(K.InstanceData(id), JSON.stringify(updated.data || {}));
+      queue.shift();
+      raw = JSON.stringify(queue);
+      await AsyncStorage.setItem(pqKey, raw);
+    } catch (e: any) {
+      if (e.message === 'Version conflict') {
+        const latest = await getInstance(id);
+        meta.etag = latest.etag;
+        meta.version = latest.version;
+        meta.currentState = latest.currentState;
+        await AsyncStorage.setItem(K.InstanceMeta(id), JSON.stringify(meta));
+        await AsyncStorage.setItem(K.InstanceData(id), JSON.stringify(latest.data || {}));
+      } else {
+        break;
+      }
+    }
+  }
+}
+
+export async function syncOnce() {
+  const raw = await AsyncStorage.getItem(K.CreateQueue);
+  let queue: CreateJob[] = raw ? JSON.parse(raw) : [];
+  while (queue.length) {
+    const job = queue[0];
+    try {
+      const created = await createInstance(
+        job.formType,
+        job.formVersion ?? undefined,
+        job.initialData,
+        job.idempotencyKey,
+      );
+      const serverId = created.formInstanceId;
+      await AsyncStorage.setItem(K.IdMap(job.tmpId), String(serverId));
+
+      const metaRaw = await AsyncStorage.getItem(K.InstanceMeta(job.tmpId));
+      const dataRaw = await AsyncStorage.getItem(K.InstanceData(job.tmpId));
+      const meta: LocalInstanceMeta = metaRaw
+        ? {
+            ...(JSON.parse(metaRaw) as LocalInstanceMeta),
+            id: String(serverId),
+            isLocal: false,
+            etag: created.etag,
+            version: created.version,
+            currentState: created.currentState,
+            formDefinitionId: created.formDefinitionId ?? null,
+          }
+        : {
+            id: String(serverId),
+            formType: job.formType,
+            formVersion: job.formVersion ?? null,
+            formDefinitionId: created.formDefinitionId ?? null,
+            currentState: created.currentState,
+            version: created.version,
+            etag: created.etag,
+            isLocal: false,
+            createdAt: new Date().toISOString(),
+          };
+      await AsyncStorage.setItem(K.InstanceMeta(serverId), JSON.stringify(meta));
+      if (dataRaw) await AsyncStorage.setItem(K.InstanceData(serverId), dataRaw);
+
+      const patchesRaw = await AsyncStorage.getItem(K.PatchQueue(job.tmpId));
+      await AsyncStorage.removeItem(K.InstanceMeta(job.tmpId));
+      await AsyncStorage.removeItem(K.InstanceData(job.tmpId));
+      await AsyncStorage.removeItem(K.PatchQueue(job.tmpId));
+      if (patchesRaw) await AsyncStorage.setItem(K.PatchQueue(serverId), patchesRaw);
+
+      queue.shift();
+      await AsyncStorage.setItem(K.CreateQueue, JSON.stringify(queue));
+
+      await drainPatchQueue(serverId, meta);
+    } catch {
+      break;
+    }
+  }
+
+  // also drain patch queues for existing server ids without create jobs
+  // For simplicity, caller can manage separately.
+}

--- a/src/offline/templatesCache.ts
+++ b/src/offline/templatesCache.ts
@@ -1,0 +1,14 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { getFormTemplates } from '@/api/formsApi';
+
+const KEY = 'cache:FormTemplates';
+
+export async function getFormTemplatesCached(online: boolean) {
+  if (online) {
+    const defs = await getFormTemplates();
+    await AsyncStorage.setItem(KEY, JSON.stringify(defs));
+    return defs;
+  }
+  const raw = await AsyncStorage.getItem(KEY);
+  return raw ? JSON.parse(raw) : [];
+}

--- a/src/offline/types.ts
+++ b/src/offline/types.ts
@@ -1,0 +1,19 @@
+export type LocalInstanceMeta = {
+  id: string;
+  formType: string;
+  formVersion?: number | null;
+  formDefinitionId?: number | null;
+  currentState: string;
+  version: number;
+  etag: string;
+  isLocal: boolean;
+  createdAt: string;
+};
+
+export type CreateJob = {
+  tmpId: string;
+  formType: string;
+  formVersion?: number | null;
+  initialData: any;
+  idempotencyKey: string;
+};


### PR DESCRIPTION
## Summary
- add offline utility modules and sync engine
- hook up background sync via new useOfflineSync
- create instances offline via createInstanceSmart in drafts screen

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a1e864d1a08328a7e38d2a856ccaf3