### PR TITLE
feat: cache form schemas for offline use

### DIFF
--- a/services/offlineHelpers/types.ts
+++ b/services/offlineHelpers/types.ts
@@ -9,6 +9,7 @@ export type LocalInstanceMeta = {
   isLocal: boolean;
   createdAt: string;
   schema: any;
+  workflow?: any;
 };
 
 export type CreateJob = {


### PR DESCRIPTION
## Summary
- cache form templates on instance creation and retrieval
- store form schema and workflow in instance metadata for offline editing
- use cached metadata in form instance screen when offline

## Testing
- `npm test`
- `npm run lint`
- `npx tsc --noEmit` *(fails: Type 'View | null' is not assignable to type 'HTMLElement | null', and other type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a23c16beac8328b4f2bd7b12c1e5ab